### PR TITLE
feat(playback): replay and export games, start design spec

### DIFF
--- a/doc/design-specification.md
+++ b/doc/design-specification.md
@@ -1,0 +1,320 @@
+# FootballSim UI Design Specification
+
+A design specification for the FootballSim UI components
+
+## Contents
+
+- [Requirements](#requirements)
+    - [1: Consistency](#1-consistency)
+        - [1.1: Color Palette](#11-color-palette)
+        - [1.2: Typography](#12-typography)
+        - [1.3: Iconography](#13-iconography)
+        - [1.4: Spacing](#14-spacing)
+        - [1.5: Error Handling](#15-error-handling)
+    - [2: Responsiveness](#2-responsiveness)
+        - [2.1: Visual Stability](#21-visual-stability)
+        - [2.2: Long Operations](#22-long-operations)
+    - [3: Accessibility](#3-accessibility)
+        - [3.1: WCAG Standard](#31-wcag-standard)
+        - [3.2: ARIA](#32-aria)
+        - [3.3: Target Sizes](#33-target-sizes)
+        - [3.4: Navigation](#34-navigation)
+        - [3.5: Text](#35-text)
+    - [4: Adaptability](#4-adaptability)
+        - [4.1: User Preferences](#41-user-preferences)
+        - [4.2: Devices](#42-devices)
+    - [5: Design Guidelines](#5-design-guidelines)
+        - [5.1: Apple HIG](#51-apple-hig)
+        - [5.2: Google Material Design](#52-google-material-design)
+
+## Requirements
+
+The following requirements govern the design of the FootballSim UI components. They MUST be followed for all new developments within the FootballSim UI.
+
+### 1: Consistency
+
+The design of the FootballSim UI MUST remain consistent across all UI components.
+
+#### 1.1: Color Palette
+
+- The FootballSim UI color palette MUST be defined as design tokens
+- The FootballSim UI MUST support both a dark mode and a light mode
+- The FootballSim UI MUST support a high-contrast mode for both dark and light mode
+    - Note: high-contrast mode is not yet implemented; it is a planned future requirement
+- FootballSim UI display modes MUST toggle based on host system preferences (`prefers-color-scheme`), MUST NOT be stored within the FootballSim application
+
+Colors are organized below by semantic role. Each token lists its light mode value followed by its dark mode value.
+
+**Background**
+
+| Role | Light | Dark |
+|------|-------|------|
+| Page base | `#ffffff` | `#11111f` |
+| Navigation | `#162267` | `#020210` |
+| Surface (primary) | `#f0f0f5` | `#1a1a2e` |
+| Surface (raised) | `#e8eaf6` | `#1a1a2e` |
+| Surface (recessed) | `#cfd2e8` | `#16213e` |
+| Interactive (default) | `#dde0ed` | `#2f2f3f` |
+| Interactive (hover) | `#cfd2e8` | `#3f3f4f` |
+| Interactive (active/pressed) | `#b8bce0` | `#4f4f5f` |
+| Card (hover) | `#e8e8f0` | `#22223a` |
+| Error | `#ffe6e6` | `#3a1a1a` |
+| Feedback ribbon | `#d3d3d3` | `#282828` |
+| Feedback ribbon progress | `#c0c0c0` | `#383838` |
+
+**Text**
+
+| Role | Light | Dark |
+|------|-------|------|
+| Primary | `#1a1a2e` | `#ffffff` |
+| Secondary | `#555555` | `#cccccc` |
+| Muted / placeholder | `#999999` | `#666666` |
+| Error | `#cc0000` | `#ff6666` |
+
+**Accent**
+
+| Role | Light | Dark |
+|------|-------|------|
+| Primary (action blue) | `#3a58b0` | `#2c4494` |
+| Primary hover | `#4a68c0` | `#3c54a4` |
+| Primary active | `#5a78d0` | `#4c64b4` |
+| Highlight / possession | `#c5a200` | `#ffd700` |
+| Status / active indicator | `#b8860b` | `#ffd700` |
+| Destructive | `#cc0000` | `#8b0000` |
+| Destructive hover | `#a00000` | `#a00000` |
+| Destructive active | `#800000` | `#cc0000` |
+| Feedback ribbon sidebar | `#c00000` | `#c00000` |
+
+**Border**
+
+| Role | Light | Dark |
+|------|-------|------|
+| Standard | `#cccccc` | `#333333` |
+| Subtle | `#bbbbbb` | `#333333` |
+| Field display | `#999999` | `#444444` |
+| Card | `#d0d0d8` | `#3a3a4e` |
+
+**Field**
+
+| Role | Value (both modes) |
+|------|-------------------|
+| Playing surface | `#2d7a2d` |
+
+#### 1.2: Typography
+
+- The FootballSim UI typography MUST be defined as design tokens
+- The FootballSim UI MUST use a system sans-serif font stack
+    - MUST NOT bundle or load custom web fonts
+- Font sizes MUST use relative units (`em`) so they scale with the user's browser default
+
+**Font family**
+
+- All components: `sans-serif` (resolved by the host operating system to the appropriate system UI font)
+
+**Type scale**
+
+The following sizes are defined relative to the inherited base font size of the component:
+
+| Role | Size | Usage |
+|------|------|-------|
+| Label (extra small) | `0.7em` | Field endzone labels |
+| Label (small) | `0.75em`–`0.85em` | Tooltips, error messages, small metadata |
+| Body (secondary) | `0.9em`–`0.95em` | Subtitles, game log play descriptions, speed options |
+| Body (default) | `1em` | Standard text |
+| Body (large) | `1.1em` | Scoreboard team names, playback control buttons |
+| Subtitle | `1.2em` | Postgame final score line |
+| Title (medium) | `1.4em` | Mode card titles (Start / Replay) |
+| Title (large) | `1.5em`–`1.6em` | Postgame winner banner, Start Game button |
+
+**Font weight**
+
+- `bold` — headings, scoreboard team names, game log drive headers, mode card titles, postgame winner banner
+- `normal` — all other body text and labels
+
+#### 1.3: Iconography
+
+- Iconography MUST be visually consistent across all FootballSim UI components
+- Icons MUST be labeled as decorative (`aria-hidden="true"`) when they do not convey information to a screen reader that is not already communicated by accompanying text or an accessible label on a parent element
+- Interactive icon buttons without visible text MUST have an accessible label (`aria-label`)
+
+**Icon styles**
+
+The FootballSim UI uses two icon styles:
+
+1. **Unicode symbols** — used in playback controls for broadly-supported, semantically meaningful glyphs:
+    - Play: `▶` (`U+25B6`)
+    - Skip to end: `⏭` (`U+23ED`)
+
+2. **Inline SVG (Feather-style)** — used for navigation, mode selection, and upload affordances. All SVG icons follow these conventions:
+    - `viewBox="0 0 24 24"` with a 24×24 coordinate space
+    - `fill="none"`, `stroke="currentColor"`, `stroke-width="2"`
+    - `stroke-linecap="round"`, `stroke-linejoin="round"`
+    - Rendered at `20px` × `20px` within touch targets
+
+**Touch target sizing**
+
+- Icons placed inside interactive buttons MUST be contained in a touch target that meets the minimum size defined in [3.3: Target Sizes](#33-target-sizes)
+- Circular icon buttons (e.g. mode card icons): `44px` × `44px`, `border-radius: 50%`
+
+#### 1.4: Spacing
+
+- The FootballSim UI spacing system MUST be defined as design tokens
+- All spacing values MUST be multiples of `4px`
+
+**Spacing scale**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| xs | `4px` | Tooltip offset, small internal padding |
+| sm | `8px` | Default button padding, gap between tightly grouped elements |
+| md | `12px` | Gap between mid-level elements (e.g. scoreboard columns) |
+| lg | `16px` | Standard section padding, gap between components |
+| xl | `20px`–`24px` | Card padding, select-view outer padding |
+| 2xl | `40px` | Large decorative padding (e.g. centered content areas) |
+
+**Border radius scale**
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| sm | `4px` | Small chips, logo images, speed menu items |
+| md | `6px` | Error message containers, tooltips |
+| default | `8px` | Buttons, scoreboard, game log, playback bar, field display |
+| lg | `12px` | Mode selection cards |
+
+**Responsive breakpoint**
+
+- Compact / medium boundary: `600px`
+    - Below `600px`: single-column layout, reduced padding and font sizes
+    - At or above `600px`: multi-column layout permitted
+
+#### 1.5: Error Handling
+
+- The FootballSim UI MUST surface error messages inline, adjacent to the action that triggered the error
+- Error messages MUST be hidden by default and MUST only appear when an error has occurred
+- Error messages MUST be dismissible or MUST automatically clear when the user successfully retries the action
+- Error containers MUST use the error color tokens defined in [1.1: Color Palette](#11-color-palette)
+
+**Error container style**
+
+```
+color:            var(--gs-error-text)   (#cc0000 light / #ff6666 dark)
+background-color: var(--gs-error-bg)    (#ffe6e6 light / #3a1a1a dark)
+border-radius:    6px
+padding:          6px 10px – 8px 12px (depending on context)
+font-size:        0.8em – 0.85em
+```
+
+**Error placement**
+
+- Form validation errors (e.g. matchup config): displayed below the form, above the submit button
+- File load errors (e.g. Replay card): displayed below the file action row, within the card
+- All error elements use `display: none` as their initial state and switch to `display: block` on error
+
+---
+
+### 2: Responsiveness
+
+The FootballSim UI components MUST be responsive to user input.
+
+#### 2.1: Visual Stability
+
+- Animations MUST appear visually smooth
+- Components MUST NOT instantly transition between states (i.e. open/closed, etc.)
+
+#### 2.2: Long operations
+
+- Buttons which trigger long inputs MUST display a loading spinner while the input is processing
+    - MAY display confirmation text when it completes
+- Text and visual containers which display content that must be loaded over the network MUST perform an idle loading animation while content is loading
+
+---
+
+### 3: Accessibility
+
+The FootballSim UI components MUST be accessible to people with sensory disabilities.
+
+#### 3.1: WCAG Standard
+
+- The FootballSim UI components MUST comply with level AA of [the WCAG 2.1 standard](https://www.w3.org/TR/WCAG21/)
+    - Note - many of the following subsections on Accessibility are duplicates of requirements from the WCAG standard given particular emphasis in this document
+
+#### 3.2: ARIA
+
+- The FootballSim UI components MUST use landmark roles wherever applicable
+- The FootballSim UI components MUST use accessibility labels when landmark roles appear multiple times
+    - MUST NOT repeat landmark roles in accessibility labels
+- Interactive FootballSim UI components MUST be assigned an ARIA role
+- Tooltips and accessibility labels MUST be added to each of the following types of elements
+    - Interactive icons or buttons with no visible text or not enough context in the text
+    - Interactive images
+    - Visual cues
+    - Meaningful icons and images (status, diagrams, illustrations)
+    - Generic links
+- Accessibility labels SHOULD describe the action performed by an interactive element
+    - SHOULD NOT describe the type of element or visual description of the element
+- Icons that do not enhance visually-impaired user experience MUST be labeled as decorative
+
+#### 3.3: Target Sizes
+
+- Target sizes across the FootballSim UI components MUST equal or exceed 48 x 48dp
+- Targets across the FootballSim UI MUST be separated by at least 8dp
+
+#### 3.4: Navigation
+
+- The FootballSim UI components MUST use heading tags (`h1`, `h2`, ...) to establish hierarchy
+    - MUST NOT skip heading levels
+    - MUST use exactly one `h1` per page
+- Important options in the FootballSim UI SHOULD be placed at the top or bottom of the screen
+- The top-down structure of the DOM SHOULD align with the visual representation of the FootballSim UI
+- Initial focus in the FootballSim UI MUST align with the most common user action
+    - MUST apply to both pages and components with multiple interactive elements
+- The primary and secondary user journeys MUST be navigatable using keyboard-only and mouse-only for all FootballSim components with multiple interactive elements
+
+#### 3.5: Text
+
+- The FootballSim UI components MUST support text resizing of at least 200%
+    - Text containers MUST respond to text resizing via increase in size, reflow, or scrolling
+    - Icon containers MUST NOT respond to text resizing unless they also contain text
+- Wrapped or truncated text MUST be visible to a screen reader
+- Container components SHOULD extend vertically or horizontally to display more text where applicable
+- Text MUST NOT be wrapped or truncated without a means of expanding the text to view that which is hidden
+    - An ellipsis (`...`) MAY be used to replace truncated text if the text is available through a tooltip or link
+
+---
+
+### 4: Adaptability
+
+The FootballSim UI should be designed to adapt to various device sizes and contexts
+
+#### 4.1: User Preferences
+
+- The FootballSim UI components SHOULD respect host system preferences wherever applicable
+- Display mode (dark / light) MUST be driven by `prefers-color-scheme` and MUST NOT be overridden by application state
+- The FootballSim UI MUST NOT store user preference state internally; all preference signals MUST originate from the host environment
+
+#### 4.2: Devices
+
+- The FootballSim UI components MUST be responsive for desktop, mobile, and tablet device sizes
+- The FootballSim UI MUST either show/hide, levitate, or re-flow panes and components on window resize
+    - MUST NOT relocate components between panes on window resize
+- The FootballSim UI MUST use only 1 pane on compact (under 600dp) and medium (600-839dp) window sizes
+    - SHOULD use 2 panes, MAY use at most 3 panes on expanded and large (840-1199dp) window sizes
+
+---
+
+### 5: Design Guidelines
+
+The FootballSim UI components SHOULD comply with platform design guidelines
+
+#### 5.1 Apple HIG
+
+- The FootballSim UI components SHOULD comply with [the Apple Human Interface Guideline (HIG)](https://developer.apple.com/design/human-interface-guidelines)
+- The FootballSim UI components MAY choose to borrow some aspects of the Apple HIG while ignoring others
+
+#### 5.2 Google Material Design
+
+- The FootballSim UI components SHOULD comply with [the Google Material Design Guideline](https://m3.material.io/)
+- The FootballSim UI components MAY choose to borrow some aspects of the Google Material Design Guideline while ignoring others
+- The FootballSim UI components MUST use design tokens to manage design decisions across various contexts
+    - For reference, see [material-foundation/material-tokens](https://github.com/material-foundation/material-tokens)
+- The FootballSim UI components with multiple interactive elements MUST define primary and secondary user journeys where applicable

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimatch": "^10.2.1"
   },
   "dependencies": {
-    "@whatsacomputertho/fbsim-core": "^1.0.0-beta.1"
+    "@whatsacomputertho/fbsim-core": "^1.0.0-beta.2-hotfix.1"
   },
   "os": ["win32", "darwin", "linux"],
   "cpu": ["x64", "arm64"],

--- a/src/__tests__/components/wact-game-sim.test.ts
+++ b/src/__tests__/components/wact-game-sim.test.ts
@@ -158,9 +158,18 @@ describe('WACTGameSim', () => {
     expect(el.root.mode).toBe('open');
   });
 
-  it('should show config view by default', () => {
+  it('should show select view by default with config view hidden', () => {
+    const selectView = el.root.getElementById('game-sim__select-view') as HTMLDivElement;
     const configView = el.root.getElementById('game-sim__config-view') as HTMLDivElement;
-    expect(configView.style.display).not.toBe('none');
+    expect(selectView.style.display).not.toBe('none');
+    expect(configView.style.display).toBe('none');
+  });
+
+  it('should have select view mode cards', () => {
+    const startCard = el.root.getElementById('game-sim__start-card');
+    const replayCard = el.root.getElementById('game-sim__replay-card');
+    expect(startCard).not.toBeNull();
+    expect(replayCard).not.toBeNull();
   });
 
   it('should have a start button', () => {
@@ -187,8 +196,10 @@ describe('WACTGameSim', () => {
   it('should have postgame buttons', () => {
     const summaryBtn = el.root.getElementById('game-sim__summary-button');
     const newGameBtn = el.root.getElementById('game-sim__new-game-button');
+    const exportBtn = el.root.getElementById('game-sim__export-button');
     expect(summaryBtn).not.toBeNull();
     expect(newGameBtn).not.toBeNull();
+    expect(exportBtn).not.toBeNull();
   });
 
   it('should accept a PlayByPlaySimService', () => {

--- a/src/__tests__/services/playback-sim-service.test.ts
+++ b/src/__tests__/services/playback-sim-service.test.ts
@@ -1,0 +1,397 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { PlaybackSimService } from '../../services/playback-sim-service.js';
+import type { GameFile } from '../../services/game-file.js';
+import type {
+  GameContext,
+  Play,
+  Drive,
+  OffensiveStats,
+  MatchupConfig,
+} from '../../services/types.js';
+
+function makeContext(overrides?: Partial<GameContext>): GameContext {
+  return {
+    home_team_short: 'HOME',
+    away_team_short: 'AWAY',
+    quarter: 1,
+    half_seconds: 1800,
+    down: 1,
+    distance: 10,
+    yard_line: 20,
+    home_score: 0,
+    away_score: 0,
+    home_timeouts: 3,
+    away_timeouts: 3,
+    home_positive_direction: true,
+    home_opening_kickoff: true,
+    home_possession: true,
+    last_play_turnover: false,
+    last_play_incomplete: false,
+    last_play_out_of_bounds: false,
+    last_play_timeout: false,
+    last_play_kickoff: false,
+    last_play_punt: false,
+    next_play_extra_point: false,
+    next_play_kickoff: false,
+    neutral_site: false,
+    end_of_half: false,
+    game_over: false,
+    ...overrides,
+  };
+}
+
+function makePlay(overrides?: Partial<Play>): Play {
+  return {
+    context: makeContext(),
+    result: {
+      type: 'Run',
+      data: {
+        yards_gained: 5,
+        play_duration: 6,
+        fumble: false,
+        return_yards: 0,
+        out_of_bounds: false,
+        touchdown: false,
+        safety: false,
+        two_point_conversion: false,
+      },
+    },
+    result_computed: {
+      net_yards: 5,
+      play_duration: 6,
+      turnover: false,
+      offense_score: 'None',
+      defense_score: 'None',
+      offense_timeout: false,
+      defense_timeout: false,
+      incomplete: false,
+      out_of_bounds: false,
+      touchback: false,
+      kickoff: false,
+      punt: false,
+      next_play_kickoff: false,
+      next_play_extra_point: false,
+    },
+    post_play: {
+      type: 'BetweenPlay',
+      data: {
+        duration: 25,
+        offense_timeout: false,
+        defense_timeout: false,
+        up_tempo: false,
+        defense_not_set: false,
+        critical_down: false,
+      },
+    },
+    post_play_computed: {
+      net_yards: 0,
+      play_duration: 25,
+      turnover: false,
+      offense_score: 'None',
+      defense_score: 'None',
+      offense_timeout: false,
+      defense_timeout: false,
+      incomplete: false,
+      out_of_bounds: false,
+      touchback: false,
+      kickoff: false,
+      punt: false,
+      next_play_kickoff: false,
+      next_play_extra_point: false,
+    },
+    description: 'Rush for 5 yards',
+    context_description: 'Q1 15:00 1st & 10 at HOME 20',
+    ...overrides,
+  };
+}
+
+function makeStats(): OffensiveStats {
+  return {
+    passing: { attempts: 10, completions: 6, touchdowns: 1, interceptions: 0, yards: 80 },
+    rushing: { rushes: 8, fumbles: 0, touchdowns: 0, yards: 40 },
+    receiving: { targets: 10, receptions: 6, touchdowns: 1, fumbles: 0, yards: 80 },
+  };
+}
+
+const minimalMatchupConfig: MatchupConfig = {
+  home: {
+    name: 'Home Team',
+    short_name: 'HOME',
+    logo: '',
+    color: '#ff0000',
+    offense: {
+      passing: 75,
+      blocking: 70,
+      rushing: 72,
+      receiving: 73,
+      scrambling: 60,
+      turnovers: 80,
+      field_goals: 78,
+      punting: 70,
+      kickoffs: 72,
+      kick_return_defense: 68,
+    },
+    defense: {
+      blitzing: 70,
+      rush_defense: 72,
+      pass_defense: 75,
+      coverage: 73,
+      turnovers: 68,
+      kick_returning: 65,
+    },
+    coach: { risk_taking: 50, run_pass: 50, up_tempo: 50 },
+  },
+  away: {
+    name: 'Away Team',
+    short_name: 'AWAY',
+    logo: '',
+    color: '#0000ff',
+    offense: {
+      passing: 70,
+      blocking: 68,
+      rushing: 65,
+      receiving: 70,
+      scrambling: 58,
+      turnovers: 75,
+      field_goals: 72,
+      punting: 68,
+      kickoffs: 70,
+      kick_return_defense: 65,
+    },
+    defense: {
+      blitzing: 68,
+      rush_defense: 70,
+      pass_defense: 72,
+      coverage: 70,
+      turnovers: 65,
+      kick_returning: 62,
+    },
+    coach: { risk_taking: 50, run_pass: 50, up_tempo: 50 },
+  },
+};
+
+// Fixture: 2 drives × 2 plays each
+function makeGameFile(): GameFile {
+  const ctx0 = makeContext({ yard_line: 20, quarter: 1, half_seconds: 1800 });
+  const ctx1 = makeContext({ yard_line: 25, quarter: 1, half_seconds: 1760 });
+  const ctx2 = makeContext({ yard_line: 30, quarter: 2, half_seconds: 900 });
+  const ctx3 = makeContext({ yard_line: 35, quarter: 2, half_seconds: 860 });
+  const finalCtx = makeContext({ yard_line: 50, quarter: 4, half_seconds: 0, game_over: true });
+
+  const play0 = makePlay({ context: ctx0, description: 'Play 0' });
+  const play1 = makePlay({ context: ctx1, description: 'Play 1' });
+  const play2 = makePlay({ context: ctx2, description: 'Play 2' });
+  const play3 = makePlay({ context: ctx3, description: 'Play 3' });
+
+  const drive0: Drive = {
+    plays: [play0, play1],
+    result: 'Punt' as Drive['result'],
+    complete: true,
+    total_yards: 5,
+    display: 'Drive 1',
+  };
+  const drive1: Drive = {
+    plays: [play2, play3],
+    result: 'Touchdown' as Drive['result'],
+    complete: true,
+    total_yards: 5,
+    display: 'Drive 2',
+  };
+
+  return {
+    version: 1,
+    matchupConfig: minimalMatchupConfig,
+    drives: [drive0, drive1],
+    finalContext: finalCtx,
+    homeStats: makeStats(),
+    awayStats: makeStats(),
+  };
+}
+
+describe('PlaybackSimService', () => {
+  let svc: PlaybackSimService;
+  let gameFile: GameFile;
+
+  beforeEach(() => {
+    svc = new PlaybackSimService();
+    gameFile = makeGameFile();
+  });
+
+  describe('isReady / initialize / simulateGame', () => {
+    it('isReady() returns true', () => {
+      expect(svc.isReady()).toBe(true);
+    });
+
+    it('initialize() resolves immediately', async () => {
+      await expect(svc.initialize()).resolves.toBeUndefined();
+    });
+
+    it('simulateGame() throws', async () => {
+      await expect(svc.simulateGame(minimalMatchupConfig as never)).rejects.toThrow();
+    });
+
+    it('createGame() throws', () => {
+      expect(() => svc.createGame(minimalMatchupConfig)).toThrow();
+    });
+  });
+
+  describe('hasActiveGame', () => {
+    it('returns false before loadGame()', () => {
+      expect(svc.hasActiveGame()).toBe(false);
+    });
+
+    it('returns true after loadGame()', () => {
+      svc.loadGame(gameFile);
+      expect(svc.hasActiveGame()).toBe(true);
+    });
+
+    it('returns false after destroyGame()', () => {
+      svc.loadGame(gameFile);
+      svc.destroyGame();
+      expect(svc.hasActiveGame()).toBe(false);
+    });
+  });
+
+  describe('loadGame()', () => {
+    it('returns correct initial GameState', () => {
+      const state = svc.loadGame(gameFile);
+      expect(state.context).toBe(gameFile.drives[0].plays[0].context);
+      expect(state.latestPlay).toBeUndefined();
+      expect(state.driveCount).toBe(0);
+      expect(state.playCount).toBe(0);
+      expect(state.complete).toBe(false);
+    });
+  });
+
+  describe('simPlay()', () => {
+    it('returns correct state for first play', () => {
+      svc.loadGame(gameFile);
+      const state = svc.simPlay();
+      expect(state.latestPlay).toBe(gameFile.drives[0].plays[0]);
+      expect(state.context).toBe(gameFile.drives[0].plays[1].context);
+      expect(state.driveCount).toBe(1);
+      expect(state.playCount).toBe(1);
+      expect(state.complete).toBe(false);
+    });
+
+    it('returns correct state for second play (still drive 0)', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      const state = svc.simPlay();
+      expect(state.latestPlay).toBe(gameFile.drives[0].plays[1]);
+      expect(state.context).toBe(gameFile.drives[1].plays[0].context);
+      expect(state.driveCount).toBe(1);
+      expect(state.playCount).toBe(2);
+      expect(state.complete).toBe(false);
+    });
+
+    it('returns correct state crossing drive boundary', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      svc.simPlay();
+      const state = svc.simPlay();
+      expect(state.latestPlay).toBe(gameFile.drives[1].plays[0]);
+      expect(state.driveCount).toBe(2);
+      expect(state.complete).toBe(false);
+    });
+
+    it('returns complete=true and finalContext on last play', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      svc.simPlay();
+      svc.simPlay();
+      const state = svc.simPlay();
+      expect(state.latestPlay).toBe(gameFile.drives[1].plays[1]);
+      expect(state.context).toBe(gameFile.finalContext);
+      expect(state.driveCount).toBe(2);
+      expect(state.complete).toBe(true);
+    });
+  });
+
+  describe('getDrive()', () => {
+    it('returns partial drive (1 play) after first simPlay()', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      const drive = svc.getDrive(0);
+      expect(drive.plays.length).toBe(1);
+      expect(drive.plays[0]).toBe(gameFile.drives[0].plays[0]);
+      expect(drive.result).toBe('None');
+      expect(drive.complete).toBe(false);
+    });
+
+    it('returns partial drive (2 plays) after second simPlay() within same drive', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      svc.simPlay();
+      const drive = svc.getDrive(0);
+      expect(drive.plays.length).toBe(2);
+      expect(drive.result).toBe('None');
+      expect(drive.complete).toBe(false);
+    });
+
+    it('returns full completed drive once we advance to the next drive', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      svc.simPlay();
+      svc.simPlay(); // first play of drive 1 — drive 0 is now past
+      const drive = svc.getDrive(0);
+      expect(drive.result).toBe('Punt');
+      expect(drive.complete).toBe(true);
+      expect(drive.plays.length).toBe(2);
+    });
+
+    it('returns full drives after simRemainder()', () => {
+      svc.loadGame(gameFile);
+      svc.simRemainder();
+      const drive0 = svc.getDrive(0);
+      const drive1 = svc.getDrive(1);
+      expect(drive0.complete).toBe(true);
+      expect(drive0.result).toBe('Punt');
+      expect(drive1.complete).toBe(true);
+      expect(drive1.result).toBe('Touchdown');
+    });
+  });
+
+  describe('simDrive()', () => {
+    it('advances to end of first drive from pre-game', () => {
+      svc.loadGame(gameFile);
+      const state = svc.simDrive();
+      expect(state.driveCount).toBe(1);
+      expect(state.latestPlay).toBe(gameFile.drives[0].plays[1]);
+      expect(state.complete).toBe(false);
+    });
+
+    it('advances to end of second drive from after first drive', () => {
+      svc.loadGame(gameFile);
+      svc.simDrive();
+      const state = svc.simDrive();
+      expect(state.driveCount).toBe(2);
+      expect(state.latestPlay).toBe(gameFile.drives[1].plays[1]);
+      expect(state.complete).toBe(true);
+    });
+  });
+
+  describe('simRemainder()', () => {
+    it('advances to game complete from pre-game', () => {
+      svc.loadGame(gameFile);
+      const state = svc.simRemainder();
+      expect(state.complete).toBe(true);
+      expect(state.context).toBe(gameFile.finalContext);
+    });
+
+    it('advances to game complete from mid-game', () => {
+      svc.loadGame(gameFile);
+      svc.simPlay();
+      const state = svc.simRemainder();
+      expect(state.complete).toBe(true);
+    });
+  });
+
+  describe('getHomeStats / getAwayStats', () => {
+    it('returns stored stats from game file', () => {
+      svc.loadGame(gameFile);
+      expect(svc.getHomeStats()).toBe(gameFile.homeStats);
+      expect(svc.getAwayStats()).toBe(gameFile.awayStats);
+    });
+  });
+});

--- a/src/components/wact-game-sim.ts
+++ b/src/components/wact-game-sim.ts
@@ -3,14 +3,16 @@ import type {
   GameState,
   MatchupConfig,
   OffensiveStats,
+  Drive,
 } from '../services/types.js';
+import type { GameFile } from '../services/game-file.js';
 import type { WACTMatchupConfig } from './wact-matchup-config.js';
 import type { WACTFieldDisplay } from './wact-field-display.js';
 import type { WACTPlaybackControls } from './wact-playback-controls.js';
 import type { WACTGameContext } from './wact-game-context.js';
 import type { WACTButton } from './wact-button.js';
 
-type SimState = 'config' | 'pregame' | 'playing' | 'paused' | 'postgame';
+type SimState = 'select' | 'config' | 'pregame' | 'playing' | 'paused' | 'postgame';
 
 const template = document.createElement('template');
 template.innerHTML = `
@@ -27,6 +29,11 @@ template.innerHTML = `
       --gs-stats-header: #b8860b;
       --gs-error-text: #cc0000;
       --gs-error-bg: #ffe6e6;
+      --gs-card-bg: #f0f0f5;
+      --gs-card-border: #d0d0d8;
+      --gs-card-hover-bg: #e8e8f0;
+      --gs-card-active-bg: #b8bce0;
+      --gs-card-placeholder: #aaa;
     }
 
     @media (prefers-color-scheme: dark) {
@@ -40,6 +47,11 @@ template.innerHTML = `
         --gs-stats-header: #ffd700;
         --gs-error-text: #ff6666;
         --gs-error-bg: #3a1a1a;
+        --gs-card-bg: #1e1e2e;
+        --gs-card-border: #3a3a4e;
+        --gs-card-hover-bg: #22223a;
+        --gs-card-active-bg: #4f4f5f;
+        --gs-card-placeholder: #555;
       }
     }
 
@@ -47,9 +59,138 @@ template.innerHTML = `
       margin-bottom: 3%;
     }
 
+    /* Select view */
+    #game-sim__select-view {
+      display: flex;
+      flex-direction: row;
+      gap: 20px;
+      padding: 24px;
+    }
+
+    .game-sim__mode-card {
+      flex: 1;
+      flex-wrap: wrap;
+      border-radius: 12px;
+      padding: 20px 24px;
+      cursor: default;
+      transition: background-color 0.15s;
+    }
+
+    #game-sim__start-card {
+      background-color: var(--gs-card-bg);
+      cursor: pointer;
+    }
+
+    #game-sim__start-card:hover {
+      background-color: var(--gs-card-hover-bg);
+    }
+
+    #game-sim__start-card:active {
+      background-color: var(--gs-card-active-bg);
+    }
+
+    #game-sim__replay-card {
+      background-color: var(--gs-card-bg);
+    }
+
+    #game-sim__replay-card.game-sim__mode-card--active {
+      cursor: pointer;
+    }
+
+    #game-sim__replay-card.game-sim__mode-card--active:hover {
+      background-color: var(--gs-card-hover-bg);
+    }
+
+    #game-sim__replay-card.game-sim__mode-card--active:active {
+      background-color: var(--gs-card-active-bg);
+    }
+
+    #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-card-title,
+    #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-card-subtitle,
+    #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-icon {
+      opacity: 0.45;
+    }
+
+    .game-sim__mode-card-title {
+      font-size: 1.4rem;
+      font-weight: bold;
+      margin-bottom: 6px;
+      color: var(--gs-postgame-text);
+    }
+
+    .game-sim__mode-card-subtitle {
+      font-size: 0.9rem;
+      color: var(--gs-postgame-score);
+    }
+
+    .game-sim__mode-card-row {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-top: 12px;
+    }
+
+    .game-sim__replay-status {
+      flex: 1;
+      min-width: 0;
+      font-size: 0.9rem;
+      color: var(--gs-card-placeholder);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    #game-sim__replay-upload-btn {
+      flex-shrink: 0;
+      --btn-padding: 12px;
+      line-height: 0;
+    }
+
+    .game-sim__mode-icon {
+      flex-shrink: 0;
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--gs-postgame-text);
+    }
+
+    .game-sim__mode-card-icons {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+      margin-left: auto;
+    }
+
+    @keyframes game-sim-spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .game-sim__card-spinner {
+      width: 18px;
+      height: 18px;
+      border: 2px solid currentColor;
+      border-top-color: transparent;
+      border-radius: 50%;
+      animation: game-sim-spin 600ms linear infinite;
+    }
+
+    #game-sim__file-error {
+      display: none;
+      color: var(--gs-error-text);
+      font-size: 0.8em;
+      margin-top: 10px;
+      padding: 6px 10px;
+      background-color: var(--gs-error-bg);
+      border-radius: 6px;
+    }
+
     /* Config view */
     #game-sim__config-view {
-      display: block;
+      display: none;
     }
 
     #game-sim__start-button-wrapper {
@@ -111,10 +252,30 @@ template.innerHTML = `
       margin-bottom: 20px;
     }
 
-    .game-sim__postgame-button {
+    #game-sim__postgame-actions {
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+      margin-bottom: 12px;
+    }
+
+    .game-sim__postgame-icon-btn {
+      font-size: 0.95rem;
+      --btn-padding: 8px 14px;
+    }
+
+    .game-sim__postgame-icon-btn span {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      line-height: 1;
+    }
+
+    #game-sim__new-game-button {
+      display: block;
+      width: 100%;
       font-size: 1rem;
-      --btn-padding: 8px 20px;
-      margin: 6px;
+      --btn-padding: 10px;
     }
 
     /* Stats view */
@@ -167,12 +328,54 @@ template.innerHTML = `
     }
 
     @media only screen and (max-width: 600px) {
+      #game-sim__select-view {
+        flex-direction: column;
+      }
+
       #game-sim__game-layout {
         flex-direction: column;
       }
     }
   </style>
   <div id="game-sim__wrapper">
+    <!-- Select view -->
+    <div id="game-sim__select-view">
+      <!-- Start card -->
+      <div id="game-sim__start-card" class="game-sim__mode-card" role="button" tabindex="0">
+        <div class="game-sim__mode-card-title">New Game</div>
+        <div class="game-sim__mode-card-subtitle">Simulate a new game</div>
+        <div class="game-sim__mode-card-row">
+          <div class="game-sim__mode-card-icons">
+            <div class="game-sim__mode-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Replay card -->
+      <div id="game-sim__replay-card" class="game-sim__mode-card">
+        <div class="game-sim__mode-card-title">Replay</div>
+        <div class="game-sim__mode-card-subtitle">Play-back a game that has already been simulated</div>
+        <div class="game-sim__mode-card-row">
+          <wact-button id="game-sim__replay-upload-btn" aria-label="Upload game file" tooltip="upload game">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+          </wact-button>
+          <span id="game-sim__replay-status" class="game-sim__replay-status">No game selected</span>
+          <div class="game-sim__mode-card-icons">
+            <div id="game-sim__replay-arrow" class="game-sim__mode-icon" aria-hidden="true">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+            </div>
+            <div id="game-sim__replay-spinner" class="game-sim__mode-icon" aria-hidden="true" style="display:none">
+              <div class="game-sim__card-spinner"></div>
+            </div>
+          </div>
+        </div>
+        <input type="file" id="game-sim__file-input" accept=".json,application/json" style="display:none">
+        <div id="game-sim__file-error"></div>
+      </div>
+    </div>
+
     <!-- Config view -->
     <div id="game-sim__config-view">
       <wact-matchup-config id="game-sim__matchup-config"></wact-matchup-config>
@@ -195,8 +398,21 @@ template.innerHTML = `
           <div id="game-sim__postgame-overlay">
             <div id="game-sim__winner-banner"></div>
             <div id="game-sim__final-score"></div>
-            <wact-button id="game-sim__summary-button" class="game-sim__postgame-button">Game Summary</wact-button>
-            <wact-button id="game-sim__new-game-button" class="game-sim__postgame-button">Simulate New Game</wact-button>
+            <div id="game-sim__postgame-actions">
+              <wact-button id="game-sim__export-button" class="game-sim__postgame-icon-btn">
+                <span>
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                  Export
+                </span>
+              </wact-button>
+              <wact-button id="game-sim__summary-button" class="game-sim__postgame-icon-btn">
+                <span>
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="20" x2="22" y2="20"/><polyline points="4 16 10 9 16 13 22 7"/></svg>
+                  Game Summary
+                </span>
+              </wact-button>
+            </div>
+            <wact-button id="game-sim__new-game-button" variant="primary">New Game</wact-button>
           </div>
         </div>
       </div>
@@ -225,12 +441,15 @@ export class WACTGameSim extends HTMLElement {
 
   readonly root: ShadowRoot;
   private simService: PlayByPlaySimService | null = null;
-  private state: SimState = 'config';
+  private state: SimState = 'select';
   private playbackTimer: ReturnType<typeof setTimeout> | null = null;
   private playbackSpeed = 2;
   private matchupConfig: MatchupConfig | null = null;
   private lastDriveCount = 0;
   private lastHomePositiveDirection: boolean | null = null;
+  private mode: 'simulate' | 'playback' = 'simulate';
+  private finalGameState: GameState | null = null;
+  private selectedGameFile: File | null = null;
 
   private _readyPromise: Promise<void> | null = null;
   private _resolveReady: (() => void) | null = null;
@@ -250,9 +469,136 @@ export class WACTGameSim extends HTMLElement {
     this.simService = service;
   }
 
+  // --- Public API ---
+
+  async loadMatchup(config: MatchupConfig): Promise<void> {
+    this.clearTimer();
+    if (this.simService?.hasActiveGame()) {
+      this.simService.destroyGame();
+    }
+
+    if (!this.simService || this.mode === 'playback') {
+      const { WasmSimService } = await import('../services/wasm-sim-service.js');
+      this.simService = new WasmSimService();
+    }
+
+    if (!this.simService.isReady()) {
+      await this.simService.initialize();
+    }
+
+    const gameState = this.simService.createGame(config);
+
+    this.matchupConfig = config;
+    this.mode = 'simulate';
+    this.lastDriveCount = 0;
+    this.lastHomePositiveDirection = null;
+    this.finalGameState = null;
+
+    this.setupScoreboard(gameState);
+    this.setupField(gameState.context.home_positive_direction);
+
+    const context = this.root.getElementById('game-sim__context') as WACTGameContext;
+    context.scoreboard.setAttribute('status', 'Pregame');
+    context.gameLog.clear();
+    context.gameLog.setTeamLogos(this.matchupConfig.home.logo, this.matchupConfig.away.logo);
+
+    this.transitionTo('pregame');
+  }
+
+  async loadGameFile(source: File | GameFile): Promise<void> {
+    let gameFile: GameFile;
+
+    if (source instanceof File) {
+      const text = await source.text();
+      let parsed: GameFile;
+      try {
+        parsed = JSON.parse(text) as GameFile;
+      } catch {
+        throw new Error('Invalid game file: not valid JSON.');
+      }
+      if (!parsed || parsed.version !== 1) {
+        throw new Error('Invalid game file: unsupported version or format.');
+      }
+      gameFile = parsed;
+    } else {
+      gameFile = source;
+    }
+
+    this.clearTimer();
+    if (this.simService?.hasActiveGame()) {
+      this.simService.destroyGame();
+    }
+
+    const { PlaybackSimService } = await import('../services/playback-sim-service.js');
+    const svc = new PlaybackSimService();
+    this.simService = svc;
+    this.mode = 'playback';
+    this.matchupConfig = gameFile.matchupConfig;
+    this.lastDriveCount = 0;
+    this.lastHomePositiveDirection = null;
+    this.finalGameState = null;
+
+    const gameState = svc.loadGame(gameFile);
+
+    this.setupScoreboard(gameState);
+    this.setupField(gameState.context.home_positive_direction);
+
+    const context = this.root.getElementById('game-sim__context') as WACTGameContext;
+    context.scoreboard.setAttribute('status', 'Pregame');
+    context.gameLog.clear();
+    context.gameLog.setTeamLogos(this.matchupConfig.home.logo, this.matchupConfig.away.logo);
+
+    this.transitionTo('pregame');
+  }
+
+  async exportGame(filename?: string): Promise<void> {
+    if (!this.simService || !this.matchupConfig || !this.finalGameState) return;
+
+    const drives: Drive[] = [];
+    for (let i = 0; i < this.finalGameState.driveCount; i++) {
+      drives.push(this.simService.getDrive(i));
+    }
+
+    const gameFile: GameFile = {
+      version: 1,
+      matchupConfig: this.matchupConfig,
+      drives,
+      finalContext: this.finalGameState.context,
+      homeStats: this.simService.getHomeStats(),
+      awayStats: this.simService.getAwayStats(),
+    };
+
+    const { downloadGameFile } = await import('../services/game-file.js');
+    downloadGameFile(gameFile, filename);
+  }
+
+  // --- Internal UI methods ---
+
+  private resetSelectView(): void {
+    this.selectedGameFile = null;
+    const replayCard = this.root.getElementById('game-sim__replay-card') as HTMLElement | null;
+    const statusEl = this.root.getElementById('game-sim__replay-status') as HTMLElement | null;
+    const fileError = this.root.getElementById('game-sim__file-error') as HTMLElement | null;
+    const arrow = this.root.getElementById('game-sim__replay-arrow') as HTMLElement | null;
+    const spinner = this.root.getElementById('game-sim__replay-spinner') as HTMLElement | null;
+    if (replayCard) {
+      replayCard.classList.remove('game-sim__mode-card--active');
+      replayCard.removeAttribute('role');
+      replayCard.removeAttribute('tabindex');
+    }
+    if (statusEl) statusEl.textContent = 'No game selected';
+    if (fileError) {
+      fileError.style.display = 'none';
+      fileError.textContent = '';
+    }
+    if (arrow) arrow.style.display = 'flex';
+    if (spinner) spinner.style.display = 'none';
+  }
+
   private transitionTo(newState: SimState): void {
     this.state = newState;
 
+    const selectView = this.root.getElementById('game-sim__select-view') as HTMLDivElement;
     const configView = this.root.getElementById('game-sim__config-view') as HTMLDivElement;
     const gameView = this.root.getElementById('game-sim__game-view') as HTMLDivElement;
     const statsView = this.root.getElementById('game-sim__stats-view') as HTMLDivElement;
@@ -263,6 +609,7 @@ export class WACTGameSim extends HTMLElement {
 
     const gameRight = this.root.getElementById('game-sim__game-right') as HTMLDivElement;
 
+    selectView.style.display = 'none';
     configView.style.display = 'none';
     gameView.style.display = 'none';
     statsView.style.display = 'none';
@@ -270,6 +617,10 @@ export class WACTGameSim extends HTMLElement {
     gameRight.style.display = 'none';
 
     switch (newState) {
+      case 'select':
+        selectView.style.display = 'flex';
+        this.resetSelectView();
+        break;
       case 'config':
         configView.style.display = 'block';
         break;
@@ -304,48 +655,51 @@ export class WACTGameSim extends HTMLElement {
 
     startButton.startLoading();
 
+    const matchupConfigEl = this.root.getElementById(
+      'game-sim__matchup-config',
+    ) as WACTMatchupConfig;
+    const config = matchupConfigEl.matchupConfig;
+
     try {
-      if (!this.simService) {
-        const { WasmSimService } = await import('../services/wasm-sim-service.js');
-        this.simService = new WasmSimService();
-      }
-
-      if (!this.simService.isReady()) {
-        await this.simService.initialize();
-      }
-
-      const matchupConfigEl = this.root.getElementById(
-        'game-sim__matchup-config',
-      ) as WACTMatchupConfig;
-      this.matchupConfig = matchupConfigEl.matchupConfig;
-
-      let gameState: GameState;
-      try {
-        gameState = this.simService.createGame(this.matchupConfig);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        errorEl.textContent = message;
-        errorEl.style.display = 'block';
-        startButton.stopLoading();
-        return;
-      }
-      errorEl.textContent = '';
-      errorEl.style.display = 'none';
-      this.lastDriveCount = 0;
-
-      this.setupScoreboard(gameState);
-      this.setupField(gameState.context.home_positive_direction);
-
-      const context = this.root.getElementById('game-sim__context') as WACTGameContext;
-      context.scoreboard.setAttribute('status', 'Pregame');
-      context.gameLog.clear();
-      context.gameLog.setTeamLogos(this.matchupConfig!.home.logo, this.matchupConfig!.away.logo);
-
-      startButton.reset();
-      this.transitionTo('pregame');
-    } catch {
+      await this.loadMatchup(config);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errorEl.textContent = message;
+      errorEl.style.display = 'block';
       startButton.stopLoading();
+      return;
     }
+
+    errorEl.textContent = '';
+    errorEl.style.display = 'none';
+    startButton.reset();
+  }
+
+  private async startPlaybackFromFile(file: File): Promise<void> {
+    const arrow = this.root.getElementById('game-sim__replay-arrow') as HTMLDivElement;
+    const spinner = this.root.getElementById('game-sim__replay-spinner') as HTMLDivElement;
+    const fileError = this.root.getElementById('game-sim__file-error') as HTMLDivElement;
+
+    fileError.style.display = 'none';
+    arrow.style.display = 'none';
+    spinner.style.display = 'flex';
+
+    try {
+      await this.loadGameFile(file);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      fileError.textContent = message;
+      fileError.style.display = 'block';
+      spinner.style.display = 'none';
+      arrow.style.display = 'flex';
+    }
+  }
+
+  private async handleExportClick(): Promise<void> {
+    const exportBtn = this.root.getElementById('game-sim__export-button') as WACTButton;
+    exportBtn.startLoading();
+    await this.exportGame();
+    exportBtn.stopLoading('Exported!', 1500);
   }
 
   private setupScoreboard(gameState: GameState): void {
@@ -583,6 +937,8 @@ export class WACTGameSim extends HTMLElement {
   }
 
   private showPostgame(gameState: GameState): void {
+    this.finalGameState = gameState;
+
     const winnerBanner = this.root.getElementById('game-sim__winner-banner') as HTMLDivElement;
     const finalScore = this.root.getElementById('game-sim__final-score') as HTMLDivElement;
 
@@ -729,10 +1085,13 @@ export class WACTGameSim extends HTMLElement {
     if (this.simService?.hasActiveGame()) {
       this.simService.destroyGame();
     }
+    this.simService = null;
     this.lastDriveCount = 0;
     this.lastHomePositiveDirection = null;
     this.matchupConfig = null;
-    this.transitionTo('config');
+    this.finalGameState = null;
+    this.mode = 'simulate';
+    this.transitionTo('select');
   }
 
   private clearTimer(): void {
@@ -746,9 +1105,68 @@ export class WACTGameSim extends HTMLElement {
     if (this._initialized) return;
     this._initialized = true;
 
+    // Initialize display state via inline styles
+    this.transitionTo(this.state);
+
+    // Select view — Start card
+    const startCard = this.root.getElementById('game-sim__start-card') as HTMLElement;
+    startCard.addEventListener('click', () => this.transitionTo('config'));
+    startCard.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        this.transitionTo('config');
+      }
+    });
+
+    // Select view — Replay card
+    const replayCard = this.root.getElementById('game-sim__replay-card') as HTMLElement;
+    const fileInput = this.root.getElementById('game-sim__file-input') as HTMLInputElement;
+    const uploadBtn = this.root.getElementById('game-sim__replay-upload-btn') as WACTButton;
+
+    uploadBtn.addEventListener('click', (e: MouseEvent) => {
+      e.stopPropagation();
+      fileInput.click();
+    });
+
+    fileInput.addEventListener('click', (e: MouseEvent) => {
+      e.stopPropagation();
+    });
+
+    fileInput.addEventListener('change', () => {
+      const statusEl = this.root.getElementById('game-sim__replay-status') as HTMLElement;
+      const fileError = this.root.getElementById('game-sim__file-error') as HTMLDivElement;
+      fileError.style.display = 'none';
+      if (fileInput.files && fileInput.files.length > 0) {
+        this.selectedGameFile = fileInput.files[0];
+        statusEl.textContent = fileInput.files[0].name;
+        replayCard.classList.add('game-sim__mode-card--active');
+        replayCard.setAttribute('role', 'button');
+        replayCard.setAttribute('tabindex', '0');
+      } else {
+        this.selectedGameFile = null;
+        statusEl.textContent = 'No game selected';
+        replayCard.classList.remove('game-sim__mode-card--active');
+        replayCard.removeAttribute('role');
+        replayCard.removeAttribute('tabindex');
+      }
+      fileInput.value = '';
+    });
+
+    replayCard.addEventListener('click', () => {
+      if (!this.selectedGameFile) return;
+      void this.startPlaybackFromFile(this.selectedGameFile);
+    });
+
+    replayCard.addEventListener('keydown', (e: KeyboardEvent) => {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      if (!this.selectedGameFile) return;
+      e.preventDefault();
+      void this.startPlaybackFromFile(this.selectedGameFile);
+    });
+
     // Start button
     const startButton = this.root.getElementById('game-sim__start-button') as HTMLElement;
-    startButton.addEventListener('click', () => this.startGame());
+    startButton.addEventListener('click', () => void this.startGame());
 
     // Playback controls
     const controls = this.root.getElementById('game-sim__controls') as WACTPlaybackControls;
@@ -780,6 +1198,9 @@ export class WACTGameSim extends HTMLElement {
 
     const newGameButton = this.root.getElementById('game-sim__new-game-button') as HTMLElement;
     newGameButton.addEventListener('click', () => this.newGame());
+
+    const exportButton = this.root.getElementById('game-sim__export-button') as HTMLElement;
+    exportButton.addEventListener('click', () => void this.handleExportClick());
 
     // Stats back button
     const statsBackButton = this.root.getElementById('game-sim__stats-back-button') as HTMLElement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,5 +29,11 @@ export type {
   Drive,
   DriveResult,
   OffensiveStats,
+  GameFile,
 } from './services/index.js';
-export { WasmSimService, ApiSimService } from './services/index.js';
+export {
+  WasmSimService,
+  ApiSimService,
+  downloadGameFile,
+  PlaybackSimService,
+} from './services/index.js';

--- a/src/services/game-file.ts
+++ b/src/services/game-file.ts
@@ -1,0 +1,22 @@
+import type { Drive, GameContext, OffensiveStats, MatchupConfig } from './types.js';
+
+export interface GameFile {
+  version: 1;
+  matchupConfig: MatchupConfig;
+  drives: Drive[];
+  finalContext: GameContext;
+  homeStats: OffensiveStats;
+  awayStats: OffensiveStats;
+}
+
+export function downloadGameFile(gameFile: GameFile, filename?: string): void {
+  const blob = new Blob([JSON.stringify(gameFile, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename ?? `game-${Date.now()}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -15,3 +15,6 @@ export type {
 } from './types.js';
 export { WasmSimService } from './wasm-sim-service.js';
 export { ApiSimService } from './api-sim-service.js';
+export type { GameFile } from './game-file.js';
+export { downloadGameFile } from './game-file.js';
+export { PlaybackSimService } from './playback-sim-service.js';

--- a/src/services/playback-sim-service.ts
+++ b/src/services/playback-sim-service.ts
@@ -1,0 +1,180 @@
+import type {
+  PlayByPlaySimService,
+  MatchupConfig,
+  GameState,
+  GameContext,
+  Drive,
+  DriveResult,
+  OffensiveStats,
+  SimResult,
+  MatchupInput,
+} from './types.js';
+import type { GameFile } from './game-file.js';
+import type { Play } from './types.js';
+
+export class PlaybackSimService implements PlayByPlaySimService {
+  private _drives: Drive[] = [];
+  private _allPlays: Play[] = [];
+  private _playDriveMap: number[] = [];
+  private _finalContext: GameContext = null!;
+  private _homeStats: OffensiveStats = null!;
+  private _awayStats: OffensiveStats = null!;
+  private _currentPlayGlobalIndex = -1;
+  private _currentPlayIndexWithinDrive = -1;
+  private _active = false;
+
+  loadGame(gameFile: GameFile): GameState {
+    this._drives = gameFile.drives;
+    this._allPlays = [];
+    this._playDriveMap = [];
+
+    for (let i = 0; i < gameFile.drives.length; i++) {
+      for (const play of gameFile.drives[i].plays) {
+        this._allPlays.push(play);
+        this._playDriveMap.push(i);
+      }
+    }
+
+    this._finalContext = gameFile.finalContext;
+    this._homeStats = gameFile.homeStats;
+    this._awayStats = gameFile.awayStats;
+    this._currentPlayGlobalIndex = -1;
+    this._currentPlayIndexWithinDrive = -1;
+    this._active = true;
+
+    return {
+      context: this._allPlays[0].context,
+      latestPlay: undefined,
+      driveCount: 0,
+      playCount: 0,
+      complete: false,
+    };
+  }
+
+  createGame(_config: MatchupConfig): GameState {
+    throw new Error('PlaybackSimService does not support createGame(). Use loadGame() instead.');
+  }
+
+  simPlay(): GameState {
+    if (!this._active) {
+      throw new Error('No active game. Call loadGame() first.');
+    }
+
+    const idx = this._currentPlayGlobalIndex + 1;
+    if (idx >= this._allPlays.length) {
+      throw new Error('Game is already complete.');
+    }
+
+    const driveIndex = this._playDriveMap[idx];
+    const prevDriveIndex =
+      this._currentPlayGlobalIndex >= 0 ? this._playDriveMap[this._currentPlayGlobalIndex] : -1;
+
+    if (driveIndex !== prevDriveIndex) {
+      this._currentPlayIndexWithinDrive = 0;
+    } else {
+      this._currentPlayIndexWithinDrive++;
+    }
+
+    this._currentPlayGlobalIndex = idx;
+
+    const currentPlay = this._allPlays[idx];
+    const isLast = idx === this._allPlays.length - 1;
+    const afterContext = isLast ? this._finalContext : this._allPlays[idx + 1].context;
+
+    return {
+      context: afterContext,
+      latestPlay: currentPlay,
+      driveCount: driveIndex + 1,
+      playCount: idx + 1,
+      complete: isLast,
+    };
+  }
+
+  simDrive(): GameState {
+    if (!this._active) {
+      throw new Error('No active game. Call loadGame() first.');
+    }
+
+    let state = this.simPlay();
+
+    while (!state.complete) {
+      const nextIdx = this._currentPlayGlobalIndex + 1;
+      if (nextIdx >= this._allPlays.length) break;
+      if (this._playDriveMap[nextIdx] !== this._playDriveMap[this._currentPlayGlobalIndex]) break;
+      state = this.simPlay();
+    }
+
+    return state;
+  }
+
+  simRemainder(): GameState {
+    if (!this._active) {
+      throw new Error('No active game. Call loadGame() first.');
+    }
+    if (this._currentPlayGlobalIndex >= this._allPlays.length - 1) {
+      throw new Error('Game is already complete.');
+    }
+
+    let state: GameState;
+    do {
+      state = this.simPlay();
+    } while (this._currentPlayGlobalIndex < this._allPlays.length - 1);
+
+    return state;
+  }
+
+  getDrive(index: number): Drive {
+    const currentDriveIndex =
+      this._currentPlayGlobalIndex >= 0 ? this._playDriveMap[this._currentPlayGlobalIndex] : -1;
+
+    const isComplete = this._currentPlayGlobalIndex === this._allPlays.length - 1;
+
+    if (isComplete || index < currentDriveIndex) {
+      return this._drives[index];
+    }
+
+    if (index === currentDriveIndex) {
+      return {
+        ...this._drives[index],
+        plays: this._drives[index].plays.slice(0, this._currentPlayIndexWithinDrive + 1),
+        result: 'None' as DriveResult,
+        complete: false,
+      };
+    }
+
+    return this._drives[index];
+  }
+
+  getHomeStats(): OffensiveStats {
+    return this._homeStats;
+  }
+
+  getAwayStats(): OffensiveStats {
+    return this._awayStats;
+  }
+
+  destroyGame(): void {
+    this._drives = [];
+    this._allPlays = [];
+    this._playDriveMap = [];
+    this._currentPlayGlobalIndex = -1;
+    this._currentPlayIndexWithinDrive = -1;
+    this._active = false;
+  }
+
+  hasActiveGame(): boolean {
+    return this._active;
+  }
+
+  isReady(): boolean {
+    return true;
+  }
+
+  async initialize(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async simulateGame(_matchup: MatchupInput): Promise<SimResult> {
+    throw new Error('PlaybackSimService does not support simulateGame().');
+  }
+}


### PR DESCRIPTION
Cherry-pick of PR:
- https://github.com/whatsacomputertho/fbsim-ui/pull/18

For reference, see:
- https://github.com/whatsacomputertho/fbsim-core/issues/97
- https://github.com/whatsacomputertho/fbsim-ui/issues/13

Includes commits:
* feat(playback): replay and export games, start design spec
* fix(svc): switch between sim services gracefully, lint errors