### PR TITLE
refac(style): implement design tokens as source of truth for styling

### DIFF
--- a/demo/design-tokens.html
+++ b/demo/design-tokens.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demo: design-tokens</title>
+    <style>
+      body {
+        margin: auto;
+        background-color: #e0e0e0;
+        font-family: sans-serif;
+        color: #333;
+      }
+      a { color: #2c4494; }
+      @media (prefers-color-scheme: dark) {
+        body { background-color: #11111f; color: #e0e0e0; }
+        a { color: #7b9ef5; }
+      }
+      .demo-wrapper {
+        padding: 2em;
+        max-width: 1100px;
+        margin: 0 auto;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-wrapper">
+      <p><a href="/">&larr; Back to index</a></p>
+      <h2>design-tokens</h2>
+      <p>Visual reference for all design tokens: reference palette, semantic system colors, typography, shape, motion, elevation, state layers, and spacing.</p>
+    </div>
+    <wact-design-tokens></wact-design-tokens>
+    <script type="module" src="/src/demo/design-tokens.ts"></script>
+  </body>
+</html>

--- a/demo/wact-button.html
+++ b/demo/wact-button.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Demo: wact-button</title>
+    <style>
+      body {
+        margin: auto;
+        background-color: #e0e0e0;
+        font-family: sans-serif;
+        color: #333;
+      }
+      a { color: #2c4494; }
+      @media (prefers-color-scheme: dark) {
+        body { background-color: #11111f; color: #e0e0e0; }
+        a { color: #7b9ef5; }
+      }
+      .demo-wrapper {
+        padding: 2em;
+        max-width: 900px;
+        margin: 0 auto;
+      }
+      .button-row {
+        display: flex;
+        gap: 1em;
+        flex-wrap: wrap;
+        align-items: center;
+        margin-bottom: 1em;
+      }
+      .narrow {
+        width: 200px;
+      }
+      code {
+        font-size: 0.85em;
+        background-color: rgba(0, 0, 0, 0.08);
+        padding: 0.1em 0.4em;
+        border-radius: 3px;
+      }
+      @media (prefers-color-scheme: dark) {
+        code { background-color: rgba(255, 255, 255, 0.12); }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="demo-wrapper">
+      <p><a href="/">&larr; Back to index</a></p>
+      <h2>wact-button</h2>
+      <p>
+        General-purpose button with three variants, disabled state, tooltip, and a loading/confirm
+        API: <code>startLoading()</code>, <code>stopLoading(confirmText?, duration?)</code>,
+        <code>reset()</code>.
+      </p>
+
+      <h3>Variants</h3>
+      <div class="button-row">
+        <wact-button>Default</wact-button>
+        <wact-button variant="primary">Primary</wact-button>
+        <wact-button variant="destructive">Destructive</wact-button>
+      </div>
+
+      <h3>Disabled</h3>
+      <div class="button-row">
+        <wact-button disabled>Default</wact-button>
+        <wact-button variant="primary" disabled>Primary</wact-button>
+        <wact-button variant="destructive" disabled>Destructive</wact-button>
+      </div>
+
+      <h3>Tooltip</h3>
+      <p>Hover over each button to see the tooltip.</p>
+      <div class="button-row">
+        <wact-button tooltip="This is a default button">Default</wact-button>
+        <wact-button variant="primary" tooltip="Saves your progress">Save</wact-button>
+        <wact-button variant="destructive" tooltip="Permanently deletes this item">Delete</wact-button>
+      </div>
+
+      <h3>Loading &amp; confirm</h3>
+      <p>
+        Click a button to start loading. After 2 seconds, <code>stopLoading()</code> is called.
+        The third button uses <code>duration: 0</code> to hold the confirm state indefinitely
+        &mdash; click <em>Reset</em> to restore it manually.
+      </p>
+      <div class="button-row">
+        <wact-button id="btn-load-reset" variant="primary">Load &rarr; reset</wact-button>
+        <wact-button id="btn-load-confirm" variant="primary">Load &rarr; confirm (1.5s)</wact-button>
+        <wact-button id="btn-load-confirm-long" variant="primary">Load &rarr; confirm (5s)</wact-button>
+        <wact-button id="btn-load-hold" variant="primary">Load &rarr; hold confirm</wact-button>
+        <wact-button id="btn-manual-reset">Reset</wact-button>
+      </div>
+
+      <h3>Custom padding</h3>
+      <p>Override internal padding with the <code>--btn-padding</code> CSS custom property.</p>
+      <div class="button-row">
+        <wact-button style="--btn-padding: 4px 8px">Compact</wact-button>
+        <wact-button>Default</wact-button>
+        <wact-button style="--btn-padding: 16px 32px">Large</wact-button>
+      </div>
+
+      <h3>Full width</h3>
+      <p>
+        <code>wact-button</code> is <code>inline-block</code> by default. Set
+        <code>display: block</code> on the host to fill its container.
+      </p>
+      <div class="narrow">
+        <wact-button variant="primary" style="display: block">Full-width button</wact-button>
+      </div>
+    </div>
+    <script type="module" src="/src/demo/wact-button.ts"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
       <h1>FBSim UI</h1>
       <p>Component demo pages. Select a component below to view it in isolation.</p>
       <ul>
+        <li><a href="/demo/wact-button.html">wact-button</a> &mdash; Button with variants, loading &amp; confirm states</li>
         <li><a href="/demo/wact-nav.html">wact-nav</a> &mdash; Sticky navigation bar</li>
         <li><a href="/demo/wact-team-select.html">wact-team-select</a> &mdash; Team selection inputs</li>
         <li><a href="/demo/wact-matchup-select.html">wact-matchup-select</a> &mdash; Home/away matchup selection</li>
@@ -52,6 +53,7 @@
         <li><a href="/demo/wact-matchup-config.html">wact-matchup-config</a> &mdash; Home/away matchup configuration</li>
         <li><a href="/demo/wact-game-context.html">wact-game-context</a> &mdash; Scoreboard + game log container</li>
         <li><a href="/demo/wact-game-sim.html">wact-game-sim</a> &mdash; Play-by-play simulation orchestrator</li>
+        <li><a href="/demo/design-tokens.html">design-tokens</a> &mdash; Design token reference: palette, typography, shape, motion &amp; more</li>
       </ul>
     </div>
   </body>

--- a/src/__tests__/components/wact-box-score.test.ts
+++ b/src/__tests__/components/wact-box-score.test.ts
@@ -49,10 +49,10 @@ describe('WACTBoxScore', () => {
     const awayScoreWrapper = el.root.getElementById(
       'box-score__away-score-wrapper',
     ) as HTMLDivElement;
-    expect(homeWrapper.style.backgroundColor).toBe('rgba(0, 63, 0, 0.7)');
-    expect(homeScoreWrapper.style.borderColor).toBe('lime');
-    expect(awayWrapper.style.backgroundColor).toBe('rgba(63, 0, 0, 0.7)');
-    expect(awayScoreWrapper.style.borderColor).toBe('red');
+    expect(homeWrapper.style.backgroundColor).toBe('rgba(0,  63,  0,  0.70)');
+    expect(homeScoreWrapper.style.borderColor).toBe('#00ff00');
+    expect(awayWrapper.style.backgroundColor).toBe('rgba(63,  0,  0,  0.70)');
+    expect(awayScoreWrapper.style.borderColor).toBe('#ff0000');
   });
 
   it('should update scores and calculate winner when away wins', () => {
@@ -66,10 +66,10 @@ describe('WACTBoxScore', () => {
     const awayScoreWrapper = el.root.getElementById(
       'box-score__away-score-wrapper',
     ) as HTMLDivElement;
-    expect(homeWrapper.style.backgroundColor).toBe('rgba(63, 0, 0, 0.7)');
-    expect(homeScoreWrapper.style.borderColor).toBe('red');
-    expect(awayWrapper.style.backgroundColor).toBe('rgba(0, 63, 0, 0.7)');
-    expect(awayScoreWrapper.style.borderColor).toBe('lime');
+    expect(homeWrapper.style.backgroundColor).toBe('rgba(63,  0,  0,  0.70)');
+    expect(homeScoreWrapper.style.borderColor).toBe('#ff0000');
+    expect(awayWrapper.style.backgroundColor).toBe('rgba(0,  63,  0,  0.70)');
+    expect(awayScoreWrapper.style.borderColor).toBe('#00ff00');
   });
 
   it('should show gray for tied scores', () => {
@@ -81,8 +81,8 @@ describe('WACTBoxScore', () => {
     const awayScoreWrapper = el.root.getElementById(
       'box-score__away-score-wrapper',
     ) as HTMLDivElement;
-    expect(homeScoreWrapper.style.borderColor).toBe('gray');
-    expect(awayScoreWrapper.style.borderColor).toBe('gray');
+    expect(homeScoreWrapper.style.borderColor).toBe('#808080');
+    expect(awayScoreWrapper.style.borderColor).toBe('#808080');
   });
 
   it('should update logo src when logo attribute changes', () => {

--- a/src/components/wact-box-score.ts
+++ b/src/components/wact-box-score.ts
@@ -1,18 +1,43 @@
+import { COLOR_CSS } from '../styles/index.js';
+import { ELEVATION_CSS } from '../styles/index.js';
+import { LAYOUT_CSS } from '../styles/index.js';
+import { SPACING_CSS } from '../styles/index.js';
+import { TYPEFACE_CSS } from '../styles/index.js';
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
-    :host {
-      --bs-overlay-bg: rgba(0, 0, 0, 0.7);
-      --bs-border-color: gray;
-      --bs-text: white;
-    }
+    ${COLOR_CSS}
+    ${ELEVATION_CSS}
+    ${LAYOUT_CSS}
+    ${SPACING_CSS}
+    ${TYPEFACE_CSS}
 
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --bs-overlay-bg: rgba(0, 0, 0, 0.7);
-        --bs-border-color: #666;
-        --bs-text: white;
-      }
+    :host {
+      /* Color palette */
+      --wact-comp-box-score-overlay-color:      var(--wact-sys-color-overlay);
+      --wact-comp-box-score-outline-color:      var(--wact-sys-color-outline-variant);
+      --wact-comp-box-score-on-overlay-color:   var(--wact-sys-color-on-image-overlay);
+      --wact-comp-box-score-win-overlay-color:  var(--wact-sys-color-win-overlay);
+      --wact-comp-box-score-win-outline-color:  var(--wact-sys-color-win-outline);
+      --wact-comp-box-score-lose-overlay-color: var(--wact-sys-color-lose-overlay);
+      --wact-comp-box-score-lose-outline-color: var(--wact-sys-color-lose-outline);
+      --wact-comp-box-score-tie-overlay-color:  var(--wact-sys-color-tie-overlay);
+      --wact-comp-box-score-tie-outline-color:  var(--wact-sys-color-tie-outline);
+
+      /* Layout */
+      --wact-comp-box-score-size:               var(--wact-ref-layout-fit-container);
+      --wact-comp-box-score-panel-height:       var(--wact-sys-layout-banner-large-height);
+      --wact-comp-box-score-panel-min-height:   var(--wact-sys-typeface-display-large-size);
+      --wact-comp-box-score-panel-max-height:   var(--wact-sys-layout-banner-large-max-height);
+      --wact-comp-box-score-text-margin:        var(--wact-ref-spacing-md);
+      --wact-comp-box-score-accent-width:       var(--wact-sys-spacing-lg);
+
+      /* Typeface */
+      --wact-comp-box-score-font-size:          var(--wact-sys-typeface-display-medium-size);
+
+      /* Elevation */
+      --wact-comp-box-score-z-index-logo:       var(--wact-sys-layer-neg-1);
     }
 
     #box-score__wrapper {
@@ -20,55 +45,57 @@ template.innerHTML = `
     }
 
     #box-score__home-wrapper, #box-score__away-wrapper {
-      position: relative;
-      width: 100%;
-      height: 20vh;
-      background-color: var(--bs-overlay-bg);
+      position:         relative;
+      width:            var(--wact-comp-box-score-size);
+      height:           var(--wact-comp-box-score-panel-height);
+      min-height:       var(--wact-comp-box-score-panel-min-height);
+      max-height:       var(--wact-comp-box-score-panel-max-height);
+      background-color: var(--wact-comp-box-score-overlay-color);
     }
 
     #box-score__home-logo, #box-score__away-logo {
-      width: 100%;
-      height: 100%;
+      position:   absolute;
       object-fit: cover;
-      position: absolute;
-      z-index: -1;
+      width:      var(--wact-comp-box-score-size);
+      height:     var(--wact-comp-box-score-size);
+      z-index:    var(--wact-comp-box-score-z-index-logo);
     }
 
     #box-score__home-score-wrapper, #box-score__away-score-wrapper {
-      width: 100%;
-      height: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      border-style: solid;
-      border-color: var(--bs-border-color);
-      box-sizing: border-box;
-      -moz-box-sizing: border-box;
+      display:            flex;
+      justify-content:    center;
+      align-items:        center;
+      width:              var(--wact-comp-box-score-size);
+      height:             var(--wact-comp-box-score-size);
+      border-style:       solid;
+      border-color:       var(--wact-comp-box-score-outline-color);
+      box-sizing:         border-box;
+      -moz-box-sizing:    border-box;
       -webkit-box-sizing: border-box;
     }
 
     #box-score__home-score-wrapper {
-      border-width: 0 0 0 16px;
+      border-width: 0 0 0 var(--wact-comp-box-score-accent-width);
     }
 
     #box-score__away-score-wrapper {
-      border-width: 0 16px 0 0;
+      border-width: 0 var(--wact-comp-box-score-accent-width) 0 0;
     }
 
     #box-score__home-team, #box-score__away-team {
-      color: var(--bs-text);
-      font-size: 2em;
-      margin: 0;
-      margin-left: 5%;
-      margin-right: 5%;
+      color:        var(--wact-comp-box-score-on-overlay-color);
+      font-size:    var(--wact-comp-box-score-font-size);
+      margin:       0;
+      margin-left:  var(--wact-comp-box-score-text-margin);
+      margin-right: var(--wact-comp-box-score-text-margin);
     }
 
     #box-score__home-score, #box-score__away-score {
-      color: var(--bs-text);
-      font-size: 2em;
-      margin: 0;
-      margin-left: 5%;
-      margin-right: 5%;
+      color:        var(--wact-comp-box-score-on-overlay-color);
+      font-size:    var(--wact-comp-box-score-font-size);
+      margin:       0;
+      margin-left:  var(--wact-comp-box-score-text-margin);
+      margin-right: var(--wact-comp-box-score-text-margin);
     }
 
     @media only screen and (max-width: 600px) {
@@ -77,7 +104,7 @@ template.innerHTML = `
       }
 
       #box-score__away-score-wrapper {
-        border-width: 0 0 0 16px;
+        border-width: 0 0 0 var(--wact-comp-box-score-accent-width);
       }
     }
   </style>
@@ -183,21 +210,29 @@ export class WACTBoxScore extends HTMLElement {
       'box-score__away-score-wrapper',
     ) as HTMLDivElement;
 
+    const style = getComputedStyle(this);
+    const winOverlay = style.getPropertyValue('--wact-comp-box-score-win-overlay-color').trim();
+    const winOutline = style.getPropertyValue('--wact-comp-box-score-win-outline-color').trim();
+    const loseOverlay = style.getPropertyValue('--wact-comp-box-score-lose-overlay-color').trim();
+    const loseOutline = style.getPropertyValue('--wact-comp-box-score-lose-outline-color').trim();
+    const tieOverlay = style.getPropertyValue('--wact-comp-box-score-tie-overlay-color').trim();
+    const tieOutline = style.getPropertyValue('--wact-comp-box-score-tie-outline-color').trim();
+
     if (homeScore > awayScore) {
-      homeWrapper.style.backgroundColor = 'rgba(0, 63, 0, 0.7)';
-      homeScoreWrapper.style.borderColor = 'lime';
-      awayWrapper.style.backgroundColor = 'rgba(63, 0, 0, 0.7)';
-      awayScoreWrapper.style.borderColor = 'red';
+      homeWrapper.style.backgroundColor = winOverlay;
+      homeScoreWrapper.style.borderColor = winOutline;
+      awayWrapper.style.backgroundColor = loseOverlay;
+      awayScoreWrapper.style.borderColor = loseOutline;
     } else if (awayScore > homeScore) {
-      homeWrapper.style.backgroundColor = 'rgba(63, 0, 0, 0.7)';
-      homeScoreWrapper.style.borderColor = 'red';
-      awayWrapper.style.backgroundColor = 'rgba(0, 63, 0, 0.7)';
-      awayScoreWrapper.style.borderColor = 'lime';
+      homeWrapper.style.backgroundColor = loseOverlay;
+      homeScoreWrapper.style.borderColor = loseOutline;
+      awayWrapper.style.backgroundColor = winOverlay;
+      awayScoreWrapper.style.borderColor = winOutline;
     } else {
-      homeWrapper.style.backgroundColor = 'rgba(0, 0, 0, 0.7)';
-      homeScoreWrapper.style.borderColor = 'gray';
-      awayWrapper.style.backgroundColor = 'rgba(0, 0, 0, 0.7)';
-      awayScoreWrapper.style.borderColor = 'gray';
+      homeWrapper.style.backgroundColor = tieOverlay;
+      homeScoreWrapper.style.borderColor = tieOutline;
+      awayWrapper.style.backgroundColor = tieOverlay;
+      awayScoreWrapper.style.borderColor = tieOutline;
     }
   }
 

--- a/src/components/wact-button.ts
+++ b/src/components/wact-button.ts
@@ -1,87 +1,97 @@
+import { COLOR_CSS } from '../styles';
+import { LAYOUT_CSS } from '../styles';
+import { MOTION_CSS } from '../styles';
+import { SHAPE_CSS } from '../styles';
+import { SPACING_CSS } from '../styles';
+import { STATE_CSS } from '../styles';
+import { TYPEFACE_CSS } from '../styles';
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
-    :host {
-      display: inline-block;
-      --btn-bg: #dde0ed;
-      --btn-bg-hover: #cfd2e8;
-      --btn-bg-active: #b8bce0;
-      --btn-text: inherit;
-    }
+    ${COLOR_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+    ${SPACING_CSS}
+    ${STATE_CSS}
+    ${TYPEFACE_CSS}
 
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --btn-bg: #2f2f3f;
-        --btn-bg-hover: #3f3f4f;
-        --btn-bg-active: #4f4f5f;
-        --btn-text: inherit;
-      }
+    :host {
+      /* Layout */
+      display: inline-block;
+      padding: 0;
+      --wact-comp-button-tooltip-label-size:      var(--wact-sys-typeface-label-medium-size);
+      --wact-comp-button-icon-size:               var(--wact-sys-typeface-body-large-size);
+
+      /* Color palette */
+      --wact-comp-button-container-color:         var(--wact-sys-color-interactive);
+      --wact-comp-button-container-color-hover:   var(--wact-sys-color-interactive-hover);
+      --wact-comp-button-container-color-active:  var(--wact-sys-color-interactive-active);
+      --wact-comp-button-label-color:             var(--wact-sys-color-on-surface);
+      --wact-comp-button-tooltip-container-color: var(--wact-sys-color-tooltip-container);
+      --wact-comp-button-tooltip-label-color:     var(--wact-sys-color-on-tooltip);
+
+      /* Shape */
+      --wact-comp-button-container-shape:         var(--wact-sys-shape-corner-medium);
+      --wact-comp-button-tooltip-container-shape: var(--wact-sys-shape-corner-extra-small);
     }
 
     :host([variant="primary"]) {
-      --btn-bg: #3a58b0;
-      --btn-bg-hover: #4a68c0;
-      --btn-bg-active: #5a78d0;
-      --btn-text: white;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host([variant="primary"]) {
-        --btn-bg: #2c4494;
-        --btn-bg-hover: #3c54a4;
-        --btn-bg-active: #4c64b4;
-        --btn-text: white;
-      }
+      --wact-comp-button-container-color:        var(--wact-sys-color-primary);
+      --wact-comp-button-container-color-hover:  var(--wact-sys-color-primary-hover);
+      --wact-comp-button-container-color-active: var(--wact-sys-color-primary-active);
+      --wact-comp-button-label-color:            var(--wact-sys-color-on-primary);
     }
 
     :host([variant="destructive"]) {
-      --btn-bg: #cc0000;
-      --btn-bg-hover: #a00000;
-      --btn-bg-active: #800000;
-      --btn-text: white;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host([variant="destructive"]) {
-        --btn-bg: #8b0000;
-        --btn-bg-hover: #a00000;
-        --btn-bg-active: #cc0000;
-        --btn-text: white;
-      }
+      --wact-comp-button-container-color:        var(--wact-sys-color-destructive);
+      --wact-comp-button-container-color-hover:  var(--wact-sys-color-destructive-hover);
+      --wact-comp-button-container-color-active: var(--wact-sys-color-destructive-active);
+      --wact-comp-button-label-color:            var(--wact-sys-color-on-destructive);
     }
 
     #btn {
-      display: block;
-      width: 100%;
+      /* Color palette */
+      color: var(--wact-comp-button-label-color);
+      background-color: var(--wact-comp-button-container-color);
+
+      /* Layout */
+      position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
+      cursor: pointer;
+      margin: 0;
+      width: var(--wact-sys-layout-fit-container);
+      min-width: var(--wact-sys-layout-min-target-size);
+      min-height: var(--wact-sys-layout-min-target-size);
+      padding: var(--wact-sys-spacing-sm);
+
+      /* Typeface */
       font: inherit;
       font-size: inherit;
-      padding: var(--btn-padding, 8px);
-      margin: 0;
-      color: var(--btn-text);
-      background-color: var(--btn-bg);
-      border: none;
-      border-radius: 8px;
-      cursor: pointer;
-      transition: all 150ms ease;
-      box-sizing: border-box;
-      position: relative;
       line-height: inherit;
-    }
 
-    :host {
-      padding: 0;
+      /* Shape */
+      border: none;
+      border-radius: var(--wact-comp-button-container-shape);
+
+      /* Motion */
+      transition: all var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
     }
 
     #btn:hover:not(:disabled) {
-      background-color: var(--btn-bg-hover);
+      background-color: var(--wact-comp-button-container-color-hover);
     }
 
     #btn:active:not(:disabled) {
-      background-color: var(--btn-bg-active);
+      background-color: var(--wact-comp-button-container-color-active);
     }
 
     #btn:disabled {
-      opacity: 0.4;
+      opacity: var(--wact-sys-state-layer-opacity-disabled);
       cursor: not-allowed;
     }
 
@@ -90,12 +100,12 @@ template.innerHTML = `
     }
 
     .spinner {
-      width: 1em;
-      height: 1em;
-      border: 2px solid var(--btn-text);
+      width: var(--wact-comp-button-icon-size);
+      height: var(--wact-comp-button-icon-size);
+      border: 2px solid var(--wact-comp-button-label-color);
       border-top-color: transparent;
-      border-radius: 50%;
-      animation: spin 600ms linear infinite;
+      border-radius: var(--wact-sys-shape-corner-full);
+      animation: spin var(--wact-sys-motion-duration-long1) var(--wact-sys-motion-easing-linear) infinite;
       display: inline-block;
       vertical-align: middle;
     }
@@ -110,22 +120,16 @@ template.innerHTML = `
       bottom: 100%;
       left: 50%;
       transform: translateX(-50%);
-      padding: 4px 8px;
-      background: #555;
-      color: white;
-      font-size: 0.75em;
-      border-radius: 4px;
+      padding: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-sm);
+      background: var(--wact-comp-button-tooltip-container-color);
+      color: var(--wact-comp-button-tooltip-label-color);
+      font-size: var(--wact-comp-button-tooltip-label-size);
+      border-radius: var(--wact-comp-button-tooltip-container-shape);
       white-space: nowrap;
       opacity: 0;
       pointer-events: none;
-      transition: opacity 150ms ease;
-      margin-bottom: 4px;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      #btn[data-tooltip]::after {
-        background: #333;
-      }
+      transition: opacity var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
+      margin-bottom: var(--wact-sys-spacing-xs);
     }
 
     #btn:hover:not(:disabled)[data-tooltip]::after {

--- a/src/components/wact-feedback-ribbon.ts
+++ b/src/components/wact-feedback-ribbon.ts
@@ -1,39 +1,45 @@
+import { COLOR_CSS, ELEVATION_CSS, LAYOUT_CSS, MOTION_CSS, SPACING_CSS } from '../styles/index.js';
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${ELEVATION_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${SPACING_CSS}
+
     :host {
       display: block;
       width: 100%;
-      --fr-bg: #d3d3d3;
-      --fr-text: inherit;
-      --fr-progress-bg: #c0c0c0;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --fr-bg: #282828;
-        --fr-text: #f5f5f5;
-        --fr-progress-bg: #383838;
-      }
+      --wact-comp-feedback-ribbon-container-color:    var(--wact-sys-color-feedback);
+      --wact-comp-feedback-ribbon-on-container-color: var(--wact-sys-color-on-surface);
+      --wact-comp-feedback-ribbon-progress-color:     var(--wact-sys-color-feedback-progress);
+      --wact-comp-feedback-ribbon-accent-color:       var(--wact-sys-color-feedback-accent);
+      --wact-comp-feedback-ribbon-shadow:             var(--wact-sys-elevation-level2);
+      --wact-comp-feedback-ribbon-progress-height:    10px;
     }
 
     .feedback-ribbon__ribbon-progress-wrapper {
-      box-shadow: 2px 2px 5px 2px rgba(0, 0, 0, 0.7);
+      box-shadow: var(--wact-comp-feedback-ribbon-shadow);
     }
 
     .feedback-ribbon__ribbon-wrapper {
+      min-height: var(--wact-sys-layout-min-target-size);
       display: grid;
       grid-template-columns: 2% 90% 8%;
-      background-color: var(--fr-bg);
+      background-color: var(--wact-comp-feedback-ribbon-container-color);
     }
 
     .feedback-ribbon__color-sidebar {
-      background-color: #C00000;
+      background-color: var(--wact-comp-feedback-ribbon-accent-color);
     }
 
     .feedback-ribbon__feedback-text-wrapper {
-      padding: 2%;
-      color: var(--fr-text);
+      display: flex;
+      align-items: center;
+      padding: var(--wact-sys-spacing-sm);
+      color: var(--wact-comp-feedback-ribbon-on-container-color);
     }
 
     .feedback-ribbon__remove-button {
@@ -47,16 +53,16 @@ template.innerHTML = `
     }
 
     .feedback-ribbon__progress-bar-wrapper {
-      height: 10px;
-      background-color: var(--fr-progress-bg);
+      height: var(--wact-comp-feedback-ribbon-progress-height);
+      background-color: var(--wact-comp-feedback-ribbon-progress-color);
     }
 
     .feedback-ribbon__progress-bar {
-      background-color: #C00000;
-      height: 10px;
+      background-color: var(--wact-comp-feedback-ribbon-accent-color);
+      height: var(--wact-comp-feedback-ribbon-progress-height);
       width: 0px;
-      transition-duration: 1000ms;
-      transition-timing-function: linear;
+      transition-duration: var(--wact-sys-motion-duration-long2);
+      transition-timing-function: var(--wact-sys-motion-easing-linear);
     }
   </style>
   <div id="ribbon-progress-wrapper" class="feedback-ribbon__ribbon-progress-wrapper">

--- a/src/components/wact-field-display.ts
+++ b/src/components/wact-field-display.ts
@@ -1,42 +1,65 @@
 import type { Play, GameContext } from '../services/types.js';
+import { COLOR_CSS, LAYOUT_CSS, MOTION_CSS, SHAPE_CSS, TYPEFACE_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+    ${TYPEFACE_CSS}
+
     :host {
       display: block;
-      font-family: sans-serif;
-      --fd-border: #999;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --fd-border: #444;
-      }
+      font-family: var(--wact-sys-typeface-font-family);
+      --wact-comp-field-display-surface-color:          var(--wact-sys-color-field);
+      --wact-comp-field-display-outline-color:          var(--wact-sys-color-outline-field);
+      --wact-comp-field-display-first-down-color:       var(--wact-sys-color-tertiary);
+      --wact-comp-field-display-container-shape:        var(--wact-sys-shape-corner-medium);
+      --wact-comp-field-display-on-field-color:         var(--wact-sys-color-on-field);
+      --wact-comp-field-display-field-line-color:       var(--wact-sys-color-field-line);
+      --wact-comp-field-display-field-label-color:      var(--wact-sys-color-field-label);
+      --wact-comp-field-display-ball-color:             var(--wact-sys-color-ball);
+      --wact-comp-field-display-ball-outline-color:     var(--wact-sys-color-on-ball);
+      --wact-comp-field-display-end-zone-width:         8%;
+      --wact-comp-field-display-field-left:             8%;
+      --wact-comp-field-display-field-width:            84%;
+      --wact-comp-field-display-hash-width:             var(--wact-ref-layout-px-1);
+      --wact-comp-field-display-line-width:             var(--wact-ref-layout-px-2);
+      --wact-comp-field-display-ball-size:              var(--wact-ref-layout-px-8);
+      --wact-comp-field-display-ball-height:            70%;
+      --wact-comp-field-display-ball-radius:            var(--wact-sys-shape-corner-micro);
+      --wact-comp-field-display-label-font-size:        var(--wact-sys-typeface-title-medium-size);
+      --wact-comp-field-display-layer-play:             var(--wact-sys-layer-2);
+      --wact-comp-field-display-layer-first-down-line:  var(--wact-sys-layer-3);
+      --wact-comp-field-display-layer-ball:             var(--wact-sys-layer-4);
+      --wact-comp-field-display-layer-ball-emoji:       var(--wact-sys-layer-5);
     }
 
     #field__wrapper {
       position: relative;
-      width: 100%;
-      height: 120px;
-      background-color: #2d7a2d;
-      border-radius: 8px;
+      width: var(--wact-ref-layout-fit-container);
+      height: var(--wact-sys-layout-field-height);
+      min-height: var(--wact-sys-layout-field-min-height);
+      background-color: var(--wact-comp-field-display-surface-color);
+      border-radius: var(--wact-comp-field-display-container-shape);
       overflow: hidden;
-      border: 2px solid var(--fd-border);
+      border: 2px solid var(--wact-comp-field-display-outline-color);
     }
 
     #field__endzone-home {
       position: absolute;
       left: 0;
       top: 0;
-      width: 8%;
-      height: 100%;
+      width: var(--wact-comp-field-display-end-zone-width);
+      height: var(--wact-ref-layout-fit-container);
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 0.7em;
-      font-weight: bold;
-      color: rgba(255, 255, 255, 0.6);
+      font-size: var(--wact-sys-typeface-label-small-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      color: var(--wact-comp-field-display-on-field-color);
       writing-mode: vertical-lr;
       text-orientation: mixed;
     }
@@ -45,83 +68,83 @@ template.innerHTML = `
       position: absolute;
       right: 0;
       top: 0;
-      width: 8%;
-      height: 100%;
+      width: var(--wact-comp-field-display-end-zone-width);
+      height: var(--wact-ref-layout-fit-container);
       display: flex;
       align-items: center;
       justify-content: center;
-      font-size: 0.7em;
-      font-weight: bold;
-      color: rgba(255, 255, 255, 0.6);
+      font-size: var(--wact-sys-typeface-label-small-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      color: var(--wact-comp-field-display-on-field-color);
       writing-mode: vertical-lr;
       text-orientation: mixed;
     }
 
     #field__playing-area {
       position: absolute;
-      left: 8%;
+      left: var(--wact-comp-field-display-field-left);
       top: 0;
-      width: 84%;
-      height: 100%;
+      width: var(--wact-comp-field-display-field-width);
+      height: var(--wact-ref-layout-fit-container);
     }
 
     .field__yard-line {
       position: absolute;
       top: 0;
-      width: 1px;
-      height: 100%;
-      background-color: rgba(255, 255, 255, 0.3);
+      width: var(--wact-comp-field-display-hash-width);
+      height: var(--wact-ref-layout-fit-container);
+      background-color: var(--wact-comp-field-display-field-line-color);
     }
 
     .field__yard-label {
       position: absolute;
       bottom: 2px;
-      font-size: 0.6em;
-      color: rgba(255, 255, 255, 0.5);
+      font-size: var(--wact-sys-typeface-label-small-size);
+      color: var(--wact-comp-field-display-field-label-color);
       transform: translateX(-50%);
     }
 
     #field__first-down-line {
       position: absolute;
       top: 0;
-      width: 2px;
-      height: 100%;
-      background-color: #ffd700;
+      width: var(--wact-comp-field-display-line-width);
+      height: var(--wact-ref-layout-fit-container);
+      background-color: var(--wact-comp-field-display-first-down-color);
       display: none;
-      z-index: 3;
-      transition: left 300ms ease;
+      z-index: var(--wact-comp-field-display-layer-first-down-line);
+      transition: left var(--wact-sys-motion-duration-medium1) var(--wact-sys-motion-easing-standard);
     }
 
     #field__ball-marker {
       position: absolute;
-      width: 10px;
-      height: 10px;
-      background-color: #8B4513;
-      border: 2px solid white;
-      border-radius: 50%;
+      width: var(--wact-comp-field-display-ball-size);
+      height: var(--wact-comp-field-display-ball-size);
+      background-color: var(--wact-comp-field-display-ball-color);
+      border: 2px solid var(--wact-comp-field-display-ball-outline-color);
+      border-radius: var(--wact-sys-shape-corner-full);
       top: 50%;
       transform: translate(-50%, -50%);
       display: none;
-      z-index: 5;
-      transition: left 300ms ease;
+      z-index: var(--wact-comp-field-display-layer-ball-emoji);
+      transition: left var(--wact-sys-motion-duration-medium1) var(--wact-sys-motion-easing-standard);
     }
 
     #field__drive-overlay {
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: 2;
+      width: var(--wact-ref-layout-fit-container);
+      height: var(--wact-ref-layout-fit-container);
+      z-index: var(--wact-comp-field-display-layer-play);
     }
 
     .field__play-rect {
       position: absolute;
       top: 15%;
-      height: 70%;
+      height: var(--wact-comp-field-display-ball-height);
       opacity: 0.5;
-      border-radius: 2px;
-      transition: opacity 200ms ease;
+      border-radius: var(--wact-comp-field-display-ball-radius);
+      transition: opacity var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     @keyframes endzoneFlash {
@@ -145,9 +168,9 @@ template.innerHTML = `
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: 8;
+      width: var(--wact-ref-layout-fit-container);
+      height: var(--wact-ref-layout-fit-container);
+      z-index: var(--wact-comp-field-display-layer-ball);
       pointer-events: none;
     }
 
@@ -156,10 +179,10 @@ template.innerHTML = `
       top: 50%;
       left: 50%;
       transform: translate(-50%, -50%);
-      z-index: 9;
+      z-index: var(--wact-comp-field-display-layer-ball-emoji);
       pointer-events: none;
-      font-size: 1.4em;
-      font-weight: bold;
+      font-size: var(--wact-comp-field-display-label-font-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
       text-shadow: 0 2px 4px rgba(0, 0, 0, 0.8);
       white-space: nowrap;
       opacity: 0;
@@ -168,32 +191,22 @@ template.innerHTML = `
     .field__endzone-flash {
       position: absolute;
       top: 0;
-      height: 100%;
+      height: var(--wact-ref-layout-fit-container);
       animation: endzoneFlash 1.2s ease forwards;
     }
 
     .field__endzone-flash--home {
       left: 0;
-      width: 8%;
+      width: var(--wact-comp-field-display-end-zone-width);
     }
 
     .field__endzone-flash--away {
       right: 0;
-      width: 8%;
+      width: var(--wact-comp-field-display-end-zone-width);
     }
 
     .field__drive-fade-out {
       animation: fadeOutRects 400ms ease forwards;
-    }
-
-    @media only screen and (max-width: 600px) {
-      #field__wrapper {
-        height: 80px;
-      }
-
-      .field__yard-label {
-        font-size: 0.5em;
-      }
     }
   </style>
   <div id="field__wrapper">

--- a/src/components/wact-final-score-sim.ts
+++ b/src/components/wact-final-score-sim.ts
@@ -1,10 +1,19 @@
 import type { MatchupInput, SimService, SimResult } from '../services/types.js';
 import type { WACTMatchupSelect } from './wact-matchup-select.js';
 import type { WACTBoxScore } from './wact-box-score.js';
+import { DESIGN_TOKENS_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${DESIGN_TOKENS_CSS}
+
+    :host {
+      --wact-comp-final-score-sim-button-font-size: var(--wact-sys-typeface-title-large-size);
+      --wact-comp-final-score-sim-button-width:     50%;
+      --wact-comp-final-score-sim-spacing:          1%;
+    }
+
     #final-score-sim__sim-button-wrapper {
       display: flex;
       align-items: center;
@@ -12,18 +21,18 @@ template.innerHTML = `
     }
 
     #final-score-sim__sim-button {
-      margin-top: 1%;
-      width: 50%;
-      font-size: 1.5rem;
+      margin-top: var(--wact-comp-final-score-sim-spacing);
+      width: var(--wact-comp-final-score-sim-button-width);
+      font-size: var(--wact-comp-final-score-sim-button-font-size);
     }
 
     #final-score-sim__result-wrapper {
       display: none;
-      margin-top: 1%;
+      margin-top: var(--wact-comp-final-score-sim-spacing);
     }
 
     #final-score-sim__wrapper {
-      margin-bottom: 3%;
+      margin-bottom: var(--wact-comp-final-score-sim-spacing);
     }
   </style>
   <div id="final-score-sim__wrapper" class="final-score-sim__wrapper">

--- a/src/components/wact-game-context.ts
+++ b/src/components/wact-game-context.ts
@@ -1,9 +1,12 @@
 import type { WACTScoreboard } from './wact-scoreboard.js';
 import type { WACTGameLog } from './wact-game-log.js';
+import { SPACING_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${SPACING_CSS}
+
     :host {
       display: block;
     }
@@ -11,7 +14,7 @@ template.innerHTML = `
     #game-context__wrapper {
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
     }
   </style>
   <div id="game-context__wrapper">

--- a/src/components/wact-game-log.ts
+++ b/src/components/wact-game-log.ts
@@ -1,67 +1,62 @@
 import type { Play, Drive } from '../services/types.js';
+import { COLOR_CSS, MOTION_CSS, SHAPE_CSS, SPACING_CSS, TYPEFACE_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+    ${SPACING_CSS}
+    ${TYPEFACE_CSS}
+
     :host {
       display: block;
-      font-family: sans-serif;
-      --gl-bg: #f0f0f5;
-      --gl-text: #444;
-      --gl-header-bg: #dde0ed;
-      --gl-header-text: #1a1a2e;
-      --gl-border: #ccc;
-      --gl-drive-hover: #e0e3f0;
-      --gl-result-text: #1a1a2e;
-      --gl-stats-text: #777;
-      --gl-chevron: #999;
-      --gl-play-border: #ddd;
-      --gl-play-context: #888;
-      --gl-play-desc: #333;
-      --gl-empty: #999;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --gl-bg: #1a1a2e;
-        --gl-text: #ccc;
-        --gl-header-bg: #16213e;
-        --gl-header-text: white;
-        --gl-border: #333;
-        --gl-drive-hover: #16213e;
-        --gl-result-text: white;
-        --gl-stats-text: #999;
-        --gl-chevron: #666;
-        --gl-play-border: #2a2a3e;
-        --gl-play-context: #888;
-        --gl-play-desc: #ddd;
-        --gl-empty: #666;
-      }
+      font-family: var(--wact-sys-typeface-font-family);
+      --wact-comp-game-log-container-color:         var(--wact-sys-color-surface);
+      --wact-comp-game-log-on-container-color:      var(--wact-sys-color-on-surface-variant);
+      --wact-comp-game-log-header-container-color:  var(--wact-sys-color-interactive);
+      --wact-comp-game-log-on-header-color:         var(--wact-sys-color-on-surface);
+      --wact-comp-game-log-divider-color:           var(--wact-sys-color-outline);
+      --wact-comp-game-log-drive-hover-color:       var(--wact-sys-color-surface-recessed);
+      --wact-comp-game-log-drive-result-color:      var(--wact-sys-color-on-surface);
+      --wact-comp-game-log-drive-stats-color:       var(--wact-sys-color-on-surface-muted);
+      --wact-comp-game-log-chevron-color:           var(--wact-sys-color-on-surface-muted);
+      --wact-comp-game-log-play-divider-color:      var(--wact-sys-color-outline-card);
+      --wact-comp-game-log-play-context-color:      var(--wact-sys-color-on-surface-muted);
+      --wact-comp-game-log-play-desc-color:         var(--wact-sys-color-on-surface);
+      --wact-comp-game-log-empty-color:             var(--wact-sys-color-on-surface-muted);
+      --wact-comp-game-log-container-shape:         var(--wact-sys-shape-corner-medium);
+      --wact-comp-game-log-max-height:              var(--wact-ref-layout-px-384);
+      --wact-comp-game-log-max-height-expanded:     var(--wact-ref-layout-px-2048);
+      --wact-comp-game-log-icon-size:               var(--wact-ref-layout-px-32);
+      --wact-comp-game-log-row-gap:                 var(--wact-sys-spacing-xs);
+      --wact-comp-game-log-play-font-style:         var(--wact-sys-typeface-weight-italic);
     }
 
     #game-log__wrapper {
-      background-color: var(--gl-bg);
-      color: var(--gl-text);
-      border-radius: 8px;
+      background-color: var(--wact-comp-game-log-container-color);
+      color: var(--wact-comp-game-log-on-container-color);
+      border-radius: var(--wact-comp-game-log-container-shape);
       overflow: hidden;
     }
 
     #game-log__header {
-      padding: 10px 16px;
-      font-size: 1.1em;
-      font-weight: bold;
-      color: var(--gl-header-text);
-      background-color: var(--gl-header-bg);
-      border-bottom: 1px solid var(--gl-border);
+      padding: var(--wact-sys-spacing-sm) var(--wact-sys-spacing-lg);
+      font-size: var(--wact-sys-typeface-body-large-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      color: var(--wact-comp-game-log-on-header-color);
+      background-color: var(--wact-comp-game-log-header-container-color);
+      border-bottom: 1px solid var(--wact-comp-game-log-divider-color);
     }
 
     #game-log__drives {
-      max-height: 400px;
+      max-height: var(--wact-comp-game-log-max-height);
       overflow-y: auto;
     }
 
     .game-log__drive {
-      border-bottom: 1px solid var(--gl-border);
+      border-bottom: 1px solid var(--wact-comp-game-log-divider-color);
     }
 
     .game-log__drive:last-child {
@@ -72,22 +67,22 @@ template.innerHTML = `
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 10px 16px;
+      padding: var(--wact-sys-spacing-sm) var(--wact-sys-spacing-lg);
       cursor: pointer;
-      transition: background-color 150ms ease;
+      transition: background-color var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
       user-select: none;
-      gap: 10px;
+      gap: var(--wact-sys-spacing-sm);
     }
 
     .game-log__drive-header:hover {
-      background-color: var(--gl-drive-hover);
+      background-color: var(--wact-comp-game-log-drive-hover-color);
     }
 
     .game-log__drive-logo {
-      width: 28px;
-      height: 28px;
+      width: var(--wact-comp-game-log-icon-size);
+      height: var(--wact-comp-game-log-icon-size);
       object-fit: contain;
-      border-radius: 4px;
+      border-radius: var(--wact-sys-shape-corner-extra-small);
       flex-shrink: 0;
     }
 
@@ -97,21 +92,21 @@ template.innerHTML = `
     }
 
     .game-log__drive-result {
-      font-weight: bold;
-      color: var(--gl-result-text);
-      font-size: 0.95em;
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      color: var(--wact-comp-game-log-drive-result-color);
+      font-size: var(--wact-sys-typeface-body-medium-size);
     }
 
     .game-log__drive-stats {
-      font-size: 0.8em;
-      color: var(--gl-stats-text);
-      margin-top: 2px;
+      font-size: var(--wact-sys-typeface-body-small-size);
+      color: var(--wact-comp-game-log-drive-stats-color);
+      margin-top: var(--wact-comp-game-log-row-gap);
     }
 
     .game-log__chevron {
-      font-size: 0.8em;
-      transition: transform 200ms ease;
-      color: var(--gl-chevron);
+      font-size: var(--wact-sys-typeface-body-small-size);
+      transition: transform var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
+      color: var(--wact-comp-game-log-chevron-color);
     }
 
     .game-log__chevron--expanded {
@@ -121,13 +116,13 @@ template.innerHTML = `
     .game-log__drive-plays {
       max-height: 0;
       overflow: hidden;
-      transition: max-height 300ms ease, padding-bottom 300ms ease;
-      padding: 0 16px;
+      transition: max-height var(--wact-sys-motion-duration-medium1) var(--wact-sys-motion-easing-standard), padding-bottom var(--wact-sys-motion-duration-medium1) var(--wact-sys-motion-easing-standard);
+      padding: 0 var(--wact-sys-spacing-lg);
     }
 
     .game-log__drive-plays--expanded {
-      max-height: 2000px;
-      padding: 0 16px 8px 16px;
+      max-height: var(--wact-comp-game-log-max-height-expanded);
+      padding: 0 var(--wact-sys-spacing-lg) var(--wact-sys-spacing-sm) var(--wact-sys-spacing-lg);
     }
 
     @keyframes fadeIn {
@@ -142,28 +137,28 @@ template.innerHTML = `
     }
 
     .game-log__play {
-      padding: 6px 0;
-      border-top: 1px solid var(--gl-play-border);
-      font-size: 0.85em;
-      line-height: 1.4;
-      animation: fadeIn 200ms ease;
+      padding: var(--wact-sys-spacing-xs) 0;
+      border-top: 1px solid var(--wact-comp-game-log-play-divider-color);
+      font-size: var(--wact-sys-typeface-body-small-size);
+      line-height: var(--wact-sys-typeface-line-height-body);
+      animation: fadeIn var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     .game-log__play-context {
-      color: var(--gl-play-context);
-      font-size: 0.9em;
+      color: var(--wact-comp-game-log-play-context-color);
+      font-size: var(--wact-sys-typeface-body-medium-size);
     }
 
     .game-log__play-description {
-      color: var(--gl-play-desc);
-      margin-top: 2px;
+      color: var(--wact-comp-game-log-play-desc-color);
+      margin-top: var(--wact-comp-game-log-row-gap);
     }
 
     .game-log__empty {
-      padding: 20px 16px;
+      padding: var(--wact-sys-spacing-xl) var(--wact-sys-spacing-lg);
       text-align: center;
-      color: var(--gl-empty);
-      font-style: italic;
+      color: var(--wact-comp-game-log-empty-color);
+      font-style: var(--wact-comp-game-log-play-font-style);
     }
 
   </style>

--- a/src/components/wact-game-sim.ts
+++ b/src/components/wact-game-sim.ts
@@ -11,48 +11,53 @@ import type { WACTFieldDisplay } from './wact-field-display.js';
 import type { WACTPlaybackControls } from './wact-playback-controls.js';
 import type { WACTGameContext } from './wact-game-context.js';
 import type { WACTButton } from './wact-button.js';
+import {
+  COLOR_CSS,
+  LAYOUT_CSS,
+  MOTION_CSS,
+  SHAPE_CSS,
+  SPACING_CSS,
+  TYPEFACE_CSS,
+} from '../styles/index.js';
 
 type SimState = 'select' | 'config' | 'pregame' | 'playing' | 'paused' | 'postgame';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+    ${SPACING_CSS}
+    ${TYPEFACE_CSS}
+
     :host {
       display: block;
-      font-family: sans-serif;
-      --gs-postgame-bg: #f0f0f5;
-      --gs-postgame-text: #333;
-      --gs-postgame-score: #555;
-      --gs-stats-bg: #f0f0f5;
-      --gs-stats-text: #1a1a2e;
-      --gs-stats-border: #ccc;
-      --gs-stats-header: #b8860b;
-      --gs-error-text: #cc0000;
-      --gs-error-bg: #ffe6e6;
-      --gs-card-bg: #f0f0f5;
-      --gs-card-border: #d0d0d8;
-      --gs-card-hover-bg: #e8e8f0;
-      --gs-card-active-bg: #b8bce0;
-      --gs-card-placeholder: #aaa;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --gs-postgame-bg: #1a1a2e;
-        --gs-postgame-text: white;
-        --gs-postgame-score: #ccc;
-        --gs-stats-bg: #1a1a2e;
-        --gs-stats-text: white;
-        --gs-stats-border: #333;
-        --gs-stats-header: #ffd700;
-        --gs-error-text: #ff6666;
-        --gs-error-bg: #3a1a1a;
-        --gs-card-bg: #1e1e2e;
-        --gs-card-border: #3a3a4e;
-        --gs-card-hover-bg: #22223a;
-        --gs-card-active-bg: #4f4f5f;
-        --gs-card-placeholder: #555;
-      }
+      font-family: var(--wact-sys-typeface-font-family);
+      --wact-comp-game-sim-card-container-color:        var(--wact-sys-color-surface);
+      --wact-comp-game-sim-card-outline-color:          var(--wact-sys-color-outline-card);
+      --wact-comp-game-sim-card-hover-color:            var(--wact-sys-color-surface-container-hover);
+      --wact-comp-game-sim-card-active-color:           var(--wact-sys-color-interactive-active);
+      --wact-comp-game-sim-card-title-color:            var(--wact-sys-color-on-surface);
+      --wact-comp-game-sim-card-subtitle-color:         var(--wact-sys-color-on-surface-variant);
+      --wact-comp-game-sim-card-placeholder-color:      var(--wact-sys-color-on-surface-muted);
+      --wact-comp-game-sim-card-disabled-color:         var(--wact-sys-color-surface);
+      --wact-comp-game-sim-card-shape:                  var(--wact-sys-shape-corner-large);
+      --wact-comp-game-sim-postgame-container-color:    var(--wact-sys-color-surface);
+      --wact-comp-game-sim-postgame-on-container-color: var(--wact-sys-color-on-surface);
+      --wact-comp-game-sim-postgame-score-color:        var(--wact-sys-color-on-surface-variant);
+      --wact-comp-game-sim-stats-container-color:       var(--wact-sys-color-surface);
+      --wact-comp-game-sim-stats-on-container-color:    var(--wact-sys-color-on-surface);
+      --wact-comp-game-sim-stats-outline-color:         var(--wact-sys-color-outline);
+      --wact-comp-game-sim-stats-header-color:          var(--wact-sys-color-tertiary-status);
+      --wact-comp-game-sim-error-label-color:           var(--wact-sys-color-error);
+      --wact-comp-game-sim-error-container-color:       var(--wact-sys-color-error-container);
+      --wact-comp-game-sim-container-shape:             var(--wact-sys-shape-corner-medium);
+      --wact-comp-game-sim-icon-size-lg:                var(--wact-ref-layout-px-48);
+      --wact-comp-game-sim-icon-size-sm:                var(--wact-ref-layout-px-16);
+      --wact-comp-game-sim-btn-padding-lg:              var(--wact-sys-spacing-md);
+      --wact-comp-game-sim-btn-padding-sm:              var(--wact-sys-spacing-sm);
     }
 
     #game-sim__wrapper {
@@ -63,78 +68,82 @@ template.innerHTML = `
     #game-sim__select-view {
       display: flex;
       flex-direction: row;
-      gap: 20px;
-      padding: 24px;
+      gap: var(--wact-sys-spacing-xl);
+      padding: var(--wact-sys-spacing-2xl);
     }
 
     .game-sim__mode-card {
       flex: 1;
       flex-wrap: wrap;
-      border-radius: 12px;
-      padding: 20px 24px;
+      border-radius: var(--wact-comp-game-sim-card-shape);
+      padding: var(--wact-sys-spacing-xl) var(--wact-sys-spacing-2xl);
       cursor: default;
-      transition: background-color 0.15s;
+      transition: background-color var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
     }
 
     #game-sim__start-card {
-      background-color: var(--gs-card-bg);
+      background-color: var(--wact-comp-game-sim-card-container-color);
       cursor: pointer;
     }
 
     #game-sim__start-card:hover {
-      background-color: var(--gs-card-hover-bg);
+      background-color: var(--wact-comp-game-sim-card-hover-color);
     }
 
     #game-sim__start-card:active {
-      background-color: var(--gs-card-active-bg);
+      background-color: var(--wact-comp-game-sim-card-active-color);
     }
 
     #game-sim__replay-card {
-      background-color: var(--gs-card-bg);
+      background-color: var(--wact-comp-game-sim-card-disabled-color);
     }
 
     #game-sim__replay-card.game-sim__mode-card--active {
+      background-color: var(--wact-comp-game-sim-card-container-color);
       cursor: pointer;
     }
 
     #game-sim__replay-card.game-sim__mode-card--active:hover {
-      background-color: var(--gs-card-hover-bg);
+      background-color: var(--wact-comp-game-sim-card-hover-color);
     }
 
     #game-sim__replay-card.game-sim__mode-card--active:active {
-      background-color: var(--gs-card-active-bg);
+      background-color: var(--wact-comp-game-sim-card-active-color);
     }
 
     #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-card-title,
-    #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-card-subtitle,
+    #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-card-subtitle {
+      color: var(--wact-sys-color-on-surface-muted);
+    }
+
     #game-sim__replay-card:not(.game-sim__mode-card--active) .game-sim__mode-icon {
-      opacity: 0.45;
+      opacity: var(--wact-sys-state-layer-opacity-inactive);
     }
 
     .game-sim__mode-card-title {
-      font-size: 1.4rem;
-      font-weight: bold;
-      margin-bottom: 6px;
-      color: var(--gs-postgame-text);
+      font-size: var(--wact-sys-typeface-title-medium-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      margin-bottom: var(--wact-sys-spacing-xs);
+      color: var(--wact-comp-game-sim-card-title-color);
     }
 
     .game-sim__mode-card-subtitle {
-      font-size: 0.9rem;
-      color: var(--gs-postgame-score);
+      font-size: var(--wact-sys-typeface-body-medium-size);
+      color: var(--wact-comp-game-sim-card-subtitle-color);
     }
 
     .game-sim__mode-card-row {
       display: flex;
       align-items: center;
-      gap: 16px;
-      margin-top: 12px;
+      gap: var(--wact-sys-spacing-lg);
+      margin-top: var(--wact-sys-spacing-md);
     }
 
     .game-sim__replay-status {
       flex: 1;
       min-width: 0;
-      font-size: 0.9rem;
-      color: var(--gs-card-placeholder);
+      font-size: var(--wact-sys-typeface-body-medium-size);
+      color: var(--wact-comp-game-sim-card-placeholder-color);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -142,25 +151,25 @@ template.innerHTML = `
 
     #game-sim__replay-upload-btn {
       flex-shrink: 0;
-      --btn-padding: 12px;
+      --btn-padding: var(--wact-comp-game-sim-btn-padding-lg);
       line-height: 0;
     }
 
     .game-sim__mode-icon {
       flex-shrink: 0;
-      width: 44px;
-      height: 44px;
+      width: var(--wact-comp-game-sim-icon-size-lg);
+      height: var(--wact-comp-game-sim-icon-size-lg);
       border-radius: 50%;
       display: flex;
       align-items: center;
       justify-content: center;
-      color: var(--gs-postgame-text);
+      color: var(--wact-comp-game-sim-card-title-color);
     }
 
     .game-sim__mode-card-icons {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
       flex-shrink: 0;
       margin-left: auto;
     }
@@ -170,22 +179,22 @@ template.innerHTML = `
     }
 
     .game-sim__card-spinner {
-      width: 18px;
-      height: 18px;
+      width: var(--wact-comp-game-sim-icon-size-sm);
+      height: var(--wact-comp-game-sim-icon-size-sm);
       border: 2px solid currentColor;
       border-top-color: transparent;
-      border-radius: 50%;
-      animation: game-sim-spin 600ms linear infinite;
+      border-radius: var(--wact-sys-shape-corner-full);
+      animation: game-sim-spin var(--wact-sys-motion-duration-long1) var(--wact-sys-motion-easing-linear) infinite;
     }
 
     #game-sim__file-error {
       display: none;
-      color: var(--gs-error-text);
-      font-size: 0.8em;
-      margin-top: 10px;
-      padding: 6px 10px;
-      background-color: var(--gs-error-bg);
-      border-radius: 6px;
+      color: var(--wact-comp-game-sim-error-label-color);
+      font-size: var(--wact-sys-typeface-body-small-size);
+      margin-top: var(--wact-sys-spacing-sm);
+      padding: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-md);
+      background-color: var(--wact-comp-game-sim-error-container-color);
+      border-radius: var(--wact-comp-game-sim-container-shape);
     }
 
     /* Config view */
@@ -197,32 +206,32 @@ template.innerHTML = `
       display: flex;
       align-items: center;
       justify-content: center;
-      margin-top: 16px;
+      margin-top: var(--wact-sys-spacing-lg);
     }
 
     #game-sim__start-button {
       width: 50%;
-      font-size: 1.5rem;
-      --btn-padding: 8px;
+      font-size: var(--wact-sys-typeface-title-large-size);
+      --btn-padding: var(--wact-sys-spacing-sm);
     }
 
     /* Game view */
     #game-sim__game-view {
       display: none;
       flex-direction: column;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
     }
 
     #game-sim__game-layout {
       display: flex;
-      gap: 12px;
+      gap: var(--wact-sys-spacing-md);
     }
 
     #game-sim__game-left {
       flex: 2;
       display: flex;
       flex-direction: column;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
     }
 
     #game-sim__game-right {
@@ -233,58 +242,58 @@ template.innerHTML = `
     /* Postgame overlay */
     #game-sim__postgame-overlay {
       display: none;
-      background-color: var(--gs-postgame-bg);
-      border-radius: 8px;
-      padding: 24px;
+      background-color: var(--wact-comp-game-sim-postgame-container-color);
+      border-radius: var(--wact-comp-game-sim-container-shape);
+      padding: var(--wact-sys-spacing-2xl);
       text-align: center;
-      color: var(--gs-postgame-text);
+      color: var(--wact-comp-game-sim-postgame-on-container-color);
     }
 
     #game-sim__winner-banner {
-      font-size: 1.6em;
+      font-size: var(--wact-sys-typeface-display-small-size);
       font-weight: bold;
-      margin-bottom: 8px;
+      margin-bottom: var(--wact-sys-spacing-sm);
     }
 
     #game-sim__final-score {
-      font-size: 1.2em;
-      color: var(--gs-postgame-score);
-      margin-bottom: 20px;
+      font-size: var(--wact-sys-typeface-title-small-size);
+      color: var(--wact-comp-game-sim-postgame-score-color);
+      margin-bottom: var(--wact-sys-spacing-xl);
     }
 
     #game-sim__postgame-actions {
       display: flex;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
       justify-content: center;
-      margin-bottom: 12px;
+      margin-bottom: var(--wact-sys-spacing-md);
     }
 
     .game-sim__postgame-icon-btn {
-      font-size: 0.95rem;
-      --btn-padding: 8px 14px;
+      font-size: var(--wact-sys-typeface-body-medium-size);
+      --btn-padding: var(--wact-sys-spacing-md);
     }
 
     .game-sim__postgame-icon-btn span {
       display: inline-flex;
       align-items: center;
-      gap: 6px;
+      gap: var(--wact-sys-spacing-xs);
       line-height: 1;
     }
 
     #game-sim__new-game-button {
       display: block;
-      width: 100%;
-      font-size: 1rem;
-      --btn-padding: 10px;
+      width: var(--wact-sys-layout-fit-container);
+      font-size: var(--wact-sys-typeface-body-default-size);
+      --btn-padding: var(--wact-comp-game-sim-btn-padding-lg);
     }
 
     /* Stats view */
     #game-sim__stats-view {
       display: none;
-      background-color: var(--gs-stats-bg);
-      border-radius: 8px;
-      padding: 16px;
-      color: var(--gs-stats-text);
+      background-color: var(--wact-comp-game-sim-stats-container-color);
+      border-radius: var(--wact-comp-game-sim-container-shape);
+      padding: var(--wact-sys-spacing-lg);
+      color: var(--wact-comp-game-sim-stats-on-container-color);
     }
 
     #game-sim__stats-view h3 {
@@ -293,37 +302,37 @@ template.innerHTML = `
     }
 
     #game-sim__stats-table {
-      width: 100%;
+      width: var(--wact-sys-layout-fit-container);
       border-collapse: collapse;
-      font-size: 0.9em;
+      font-size: var(--wact-sys-typeface-body-medium-size);
     }
 
     #game-sim__stats-table th,
     #game-sim__stats-table td {
-      padding: 6px 12px;
+      padding: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-md);
       text-align: center;
-      border-bottom: 1px solid var(--gs-stats-border);
+      border-bottom: 1px solid var(--wact-comp-game-sim-stats-outline-color);
     }
 
     #game-sim__stats-table th {
-      color: var(--gs-stats-header);
+      color: var(--wact-comp-game-sim-stats-header-color);
     }
 
     #game-sim__stats-back-button {
       display: block;
-      margin: 12px auto 0 auto;
-      font-size: 0.9rem;
-      --btn-padding: 6px 16px;
+      margin: var(--wact-sys-spacing-md) auto 0 auto;
+      font-size: var(--wact-sys-typeface-body-medium-size);
+      --btn-padding: var(--wact-comp-game-sim-btn-padding-sm);
     }
 
     #game-sim__error {
       display: none;
-      color: var(--gs-error-text);
-      font-size: 0.85em;
-      margin-top: 10px;
-      padding: 8px 12px;
-      background-color: var(--gs-error-bg);
-      border-radius: 6px;
+      color: var(--wact-comp-game-sim-error-label-color);
+      font-size: var(--wact-sys-typeface-body-small-size);
+      margin-top: var(--wact-sys-spacing-sm);
+      padding: var(--wact-sys-spacing-sm) var(--wact-sys-spacing-md);
+      background-color: var(--wact-comp-game-sim-error-container-color);
+      border-radius: var(--wact-comp-game-sim-container-shape);
       text-align: center;
     }
 

--- a/src/components/wact-matchup-config.ts
+++ b/src/components/wact-matchup-config.ts
@@ -1,28 +1,35 @@
 import type { MatchupConfig } from '../services/types.js';
 import type { WACTTeamConfig } from './wact-team-config.js';
+import { LAYOUT_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${LAYOUT_CSS}
+
+    :host {
+      --wact-comp-matchup-column-padding-h: 1%;
+    }
+
     #matchup-config__wrapper {
       display: flex;
     }
 
     #matchup-config__home {
-      width: 100%;
-      padding-right: 1%;
+      width: var(--wact-sys-layout-fit-container);
+      padding-right: var(--wact-comp-matchup-column-padding-h);
     }
 
     #matchup-config__away {
       width: 100%;
-      padding-left: 1%;
+      padding-left: var(--wact-comp-matchup-column-padding-h);
     }
 
     @media only screen and (max-width: 600px) {
       #matchup-config__wrapper {
         display: flex;
         flex-direction: column;
-        gap: 16px;
+        gap: var(--wact-sys-spacing-lg);
       }
       #matchup-config__home {
         padding-right: 0;

--- a/src/components/wact-matchup-select.ts
+++ b/src/components/wact-matchup-select.ts
@@ -1,21 +1,28 @@
 import type { MatchupInput } from '../services/types.js';
 import type { WACTTeamSelect } from './wact-team-select.js';
+import { LAYOUT_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${LAYOUT_CSS}
+
+    :host {
+      --wact-comp-matchup-column-padding-h: 1%;
+    }
+
     #matchup-select__wrapper {
       display: flex;
     }
 
     #matchup-select__home {
-      width: 100%;
-      padding-right: 1%;
+      width: var(--wact-sys-layout-fit-container);
+      padding-right: var(--wact-comp-matchup-column-padding-h);
     }
 
     #matchup-select__away {
-      width: 100%;
-      padding-left: 1%;
+      width: var(--wact-sys-layout-fit-container);
+      padding-left: var(--wact-comp-matchup-column-padding-h);
     }
 
     @media only screen and (max-width: 600px) {

--- a/src/components/wact-nav.ts
+++ b/src/components/wact-nav.ts
@@ -1,19 +1,21 @@
+import { COLOR_CSS, ELEVATION_CSS, LAYOUT_CSS } from '../styles/index.js';
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
-    :host {
-      --nav-bg: #162267;
-    }
+    ${COLOR_CSS}
+    ${ELEVATION_CSS}
+    ${LAYOUT_CSS}
 
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --nav-bg: #020210;
-      }
+    :host {
+      --wact-comp-nav-container-color:  var(--wact-sys-color-nav);
+      --wact-comp-nav-container-height: var(--wact-ref-layout-vh-10);
+      --wact-comp-nav-container-zindex: var(--wact-sys-zindex-sticky);
     }
 
     .navbar-wrapper {
-      height: 10vh;
-      background-color: var(--nav-bg);
+      height: var(--wact-comp-nav-container-height);
+      background-color: var(--wact-comp-nav-container-color);
       display: flex;
       text-align: center;
       align-items: center;
@@ -22,11 +24,11 @@ template.innerHTML = `
       top: 0;
       left: 0;
       right: 0;
-      width: 100%;
-      z-index: 1000;
+      width: var(--wact-sys-layout-fit-container);
+      z-index: var(--wact-comp-nav-container-zindex);
     }
     ::slotted(img) {
-      max-height: 100%;
+      max-height: var(--wact-sys-layout-fit-container);
       object-fit: contain;
     }
   </style>

--- a/src/components/wact-playback-controls.ts
+++ b/src/components/wact-playback-controls.ts
@@ -1,53 +1,54 @@
+import { COLOR_CSS, ELEVATION_CSS, SHAPE_CSS, SPACING_CSS } from '../styles/index.js';
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${ELEVATION_CSS}
+    ${SHAPE_CSS}
+    ${SPACING_CSS}
+
     :host {
       display: block;
-      font-family: sans-serif;
-      --pb-bg: #e8eaf6;
-      --pb-text: #1a1a2e;
-      --pb-speed-bg: #dde0ed;
-      --pb-speed-hover-bg: #cfd2e8;
-      --pb-speed-active-bg: #b8bce0;
-      --pb-menu-bg: #dde0ed;
-      --pb-menu-text: #555;
-      --pb-menu-hover-bg: #cfd2e8;
-      --pb-menu-active: #b8860b;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --pb-bg: #1a1a2e;
-        --pb-text: white;
-        --pb-speed-bg: #2f2f3f;
-        --pb-speed-hover-bg: #3f3f4f;
-        --pb-speed-active-bg: #4f4f5f;
-        --pb-menu-bg: #2f2f3f;
-        --pb-menu-text: #ccc;
-        --pb-menu-hover-bg: #3f3f4f;
-        --pb-menu-active: #ffd700;
-      }
+      font-family: var(--wact-sys-typeface-font-family);
+      --wact-comp-playback-controls-container-color:         var(--wact-sys-color-surface-raised);
+      --wact-comp-playback-controls-on-container-color:      var(--wact-sys-color-on-surface);
+      --wact-comp-playback-controls-speed-container-color:   var(--wact-sys-color-interactive);
+      --wact-comp-playback-controls-speed-hover-color:       var(--wact-sys-color-interactive-hover);
+      --wact-comp-playback-controls-speed-active-color:      var(--wact-sys-color-interactive-active);
+      --wact-comp-playback-controls-menu-container-color:    var(--wact-sys-color-interactive);
+      --wact-comp-playback-controls-menu-label-color:        var(--wact-sys-color-on-surface-variant);
+      --wact-comp-playback-controls-menu-hover-color:        var(--wact-sys-color-interactive-hover);
+      --wact-comp-playback-controls-menu-active-label-color: var(--wact-sys-color-tertiary-status);
+      --wact-comp-playback-controls-container-shape:         var(--wact-sys-shape-corner-medium);
+      --wact-comp-playback-controls-menu-shadow:             var(--wact-sys-elevation-level1);
+      --wact-comp-playback-controls-menu-zindex:             var(--wact-sys-zindex-dropdown);
+      --wact-comp-playback-controls-btn-size:                var(--wact-sys-layout-min-target-size);
+      --wact-comp-playback-controls-label-min-width:         var(--wact-ref-layout-px-64);
+      --wact-comp-playback-controls-btn-padding:             6px 14px;
+      --wact-comp-playback-controls-btn-padding-compact:     4px 10px;
+      --wact-comp-playback-controls-speed-padding-h:         10px;
     }
 
     #playback__wrapper {
       display: flex;
       align-items: center;
       justify-content: space-between;
-      padding: 8px 16px;
-      background-color: var(--pb-bg);
-      border-radius: 8px;
-      color: var(--pb-text);
-      gap: 12px;
+      padding: var(--wact-sys-spacing-sm) var(--wact-sys-spacing-lg);
+      background-color: var(--wact-comp-playback-controls-container-color);
+      border-radius: var(--wact-comp-playback-controls-container-shape);
+      color: var(--wact-comp-playback-controls-on-container-color);
+      gap: var(--wact-sys-spacing-md);
     }
 
     .playback__button {
-      font-size: 1.1em;
-      --btn-padding: 6px 14px;
-      font-family: sans-serif;
+      font-size: var(--wact-sys-typeface-body-large-size);
+      --btn-padding: var(--wact-comp-playback-controls-btn-padding);
+      font-family: var(--wact-sys-typeface-font-family);
     }
 
     #playback__play-pause {
-      width: 48px;
+      width: var(--wact-comp-playback-controls-btn-size);
       text-align: center;
       box-sizing: border-box;
     }
@@ -55,13 +56,13 @@ template.innerHTML = `
     #playback__left {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
     }
 
     #playback__right {
       display: flex;
       align-items: center;
-      gap: 8px;
+      gap: var(--wact-sys-spacing-sm);
     }
 
     #playback__speed-wrapper {
@@ -69,48 +70,49 @@ template.innerHTML = `
     }
 
     #playback__speed-display {
-      background-color: var(--pb-speed-bg);
+      background-color: var(--wact-comp-playback-controls-speed-container-color);
       border: none;
-      color: var(--pb-text);
-      font-size: 1.1em;
-      padding: 6px 14px;
-      border-radius: 8px;
+      color: var(--wact-comp-playback-controls-on-container-color);
+      font-size: var(--wact-sys-typeface-body-large-size);
+      padding: var(--wact-comp-playback-controls-btn-padding);
+      border-radius: var(--wact-comp-playback-controls-container-shape);
       cursor: pointer;
-      transition: all 150ms ease;
-      font-family: sans-serif;
-      min-width: 48px;
+      transition: all var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
+      font-family: var(--wact-sys-typeface-font-family);
+      min-width: var(--wact-comp-playback-controls-btn-size);
+      height: var(--wact-comp-playback-controls-btn-size);
       text-align: center;
     }
 
     #playback__speed-display:hover:not(:disabled) {
-      background-color: var(--pb-speed-hover-bg);
+      background-color: var(--wact-comp-playback-controls-speed-hover-color);
     }
 
     #playback__speed-display:active:not(:disabled) {
-      background-color: var(--pb-speed-active-bg);
+      background-color: var(--wact-comp-playback-controls-speed-active-color);
     }
 
     #playback__speed-display:disabled {
-      opacity: 0.4;
+      opacity: var(--wact-sys-state-layer-opacity-disabled);
       cursor: not-allowed;
     }
 
     #playback__speed-menu {
       position: absolute;
-      bottom: 100%;
+      bottom: var(--wact-sys-layout-fit-container);
       left: 50%;
       transform: translateX(-50%);
-      background-color: var(--pb-menu-bg);
+      background-color: var(--wact-comp-playback-controls-menu-container-color);
       border: none;
-      border-radius: 8px;
-      padding: 4px 0;
-      margin-bottom: 4px;
+      border-radius: var(--wact-comp-playback-controls-container-shape);
+      padding: var(--wact-sys-spacing-xs) 0;
+      margin-bottom: var(--wact-sys-spacing-xs);
       opacity: 0;
       visibility: hidden;
-      transition: opacity 150ms ease, visibility 150ms ease;
-      z-index: 10;
-      min-width: 60px;
-      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      transition: opacity var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard), visibility var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
+      z-index: var(--wact-comp-playback-controls-menu-zindex);
+      min-width: var(--wact-comp-playback-controls-label-min-width);
+      box-shadow: var(--wact-comp-playback-controls-menu-shadow);
     }
 
     #playback__speed-wrapper:hover #playback__speed-menu {
@@ -120,44 +122,43 @@ template.innerHTML = `
 
     .playback__speed-option {
       display: block;
-      width: 100%;
-      padding: 6px 12px;
+      width: var(--wact-sys-layout-fit-container);
+      padding: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-md);
       background: none;
       border: none;
-      color: var(--pb-menu-text);
-      font-size: 0.95em;
+      color: var(--wact-comp-playback-controls-menu-label-color);
+      font-size: var(--wact-sys-typeface-body-medium-size);
       cursor: pointer;
       text-align: center;
-      font-family: sans-serif;
+      font-family: var(--wact-sys-typeface-font-family);
       white-space: nowrap;
-      transition: background-color 150ms ease;
-      border-radius: 4px;
+      transition: background-color var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
+      border-radius: var(--wact-sys-shape-corner-extra-small);
     }
 
     .playback__speed-option:hover {
-      background-color: var(--pb-menu-hover-bg);
-      color: var(--pb-menu-active);
+      background-color: var(--wact-comp-playback-controls-menu-hover-color);
+      color: var(--wact-comp-playback-controls-menu-active-label-color);
     }
 
     .playback__speed-option--active {
-      color: var(--pb-menu-active);
-      font-weight: bold;
+      color: var(--wact-comp-playback-controls-menu-active-label-color);
+      font-weight: var(--wact-sys-typeface-weight-bold);
     }
 
     @media only screen and (max-width: 600px) {
       #playback__wrapper {
-        padding: 6px 10px;
+        padding: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-md);
       }
 
       .playback__button {
-        font-size: 0.9em;
-        --btn-padding: 4px 10px;
+        font-size: var(--wact-sys-typeface-body-medium-size);
+        --btn-padding: var(--wact-comp-playback-controls-btn-padding-compact);
       }
 
-
       #playback__speed-display {
-        font-size: 0.9em;
-        padding: 4px 10px;
+        font-size: var(--wact-sys-typeface-body-medium-size);
+        padding: var(--wact-comp-playback-controls-btn-padding-compact);
       }
     }
   </style>

--- a/src/components/wact-scoreboard.ts
+++ b/src/components/wact-scoreboard.ts
@@ -1,38 +1,35 @@
+import { COLOR_CSS, LAYOUT_CSS, MOTION_CSS, SHAPE_CSS, SPACING_CSS } from '../styles/index.js';
+
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+    ${SPACING_CSS}
+
     :host {
       display: block;
-      font-family: sans-serif;
-      --sb-bg: #e8eaf6;
-      --sb-text: #1a1a2e;
-      --sb-context-bg: #cfd2e8;
-      --sb-context-text: #555;
-      --sb-divider: #bbb;
-      --sb-border: #bbb;
-      --sb-possession: #c5a200;
-      --sb-status: #b8860b;
-      --sb-flash: #c5a200;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --sb-bg: #1a1a2e;
-        --sb-text: white;
-        --sb-context-bg: #16213e;
-        --sb-context-text: #ccc;
-        --sb-divider: #333;
-        --sb-border: #333;
-        --sb-possession: #ffd700;
-        --sb-status: #ffd700;
-        --sb-flash: #ffd700;
-      }
+      font-family: var(--wact-sys-typeface-font-family);
+      --wact-comp-scoreboard-container-color:         var(--wact-sys-color-surface-raised);
+      --wact-comp-scoreboard-on-container-color:      var(--wact-sys-color-on-surface);
+      --wact-comp-scoreboard-context-container-color: var(--wact-sys-color-surface-recessed);
+      --wact-comp-scoreboard-on-context-color:        var(--wact-sys-color-on-surface-variant);
+      --wact-comp-scoreboard-divider-color:           var(--wact-sys-color-outline-variant);
+      --wact-comp-scoreboard-possession-color:        var(--wact-sys-color-tertiary);
+      --wact-comp-scoreboard-status-color:            var(--wact-sys-color-tertiary-status);
+      --wact-comp-scoreboard-container-shape:         var(--wact-sys-shape-corner-medium);
+      --wact-comp-scoreboard-logo-size:               var(--wact-ref-layout-px-48);
+      --wact-comp-scoreboard-icon-size:               var(--wact-ref-layout-px-32);
+      --wact-comp-scoreboard-divider-width:           var(--wact-ref-layout-px-2);
+      --wact-comp-scoreboard-accent-width:            var(--wact-ref-layout-px-4);
     }
 
     #scoreboard__wrapper {
-      background-color: var(--sb-bg);
-      color: var(--sb-text);
-      border-radius: 8px;
+      background-color: var(--wact-comp-scoreboard-container-color);
+      color: var(--wact-comp-scoreboard-on-container-color);
+      border-radius: var(--wact-comp-scoreboard-container-shape);
       overflow: hidden;
     }
 
@@ -46,10 +43,10 @@ template.innerHTML = `
       flex: 1;
       display: flex;
       align-items: center;
-      padding: 12px 16px;
-      gap: 12px;
-      border-left: 4px solid transparent;
-      transition: border-color 200ms ease-in-out;
+      padding: var(--wact-sys-spacing-md) var(--wact-sys-spacing-lg);
+      gap: var(--wact-sys-spacing-md);
+      border-left: var(--wact-comp-scoreboard-accent-width) solid var(--wact-sys-color-transparent);
+      transition: border-color var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     .scoreboard__team--home {
@@ -60,30 +57,30 @@ template.innerHTML = `
       justify-content: flex-end;
       flex-direction: row-reverse;
       border-left: none;
-      border-right: 4px solid transparent;
+      border-right: var(--wact-comp-scoreboard-accent-width) solid var(--wact-sys-color-transparent);
     }
 
     .scoreboard__team--possession {
-      border-color: var(--sb-possession);
+      border-color: var(--wact-comp-scoreboard-possession-color);
     }
 
     .scoreboard__team-logo {
-      width: 40px;
-      height: 40px;
+      width: var(--wact-comp-scoreboard-logo-size);
+      height: var(--wact-comp-scoreboard-logo-size);
       object-fit: contain;
-      border-radius: 4px;
+      border-radius: var(--wact-sys-shape-corner-extra-small);
     }
 
     .scoreboard__team-name {
-      font-size: 1.1em;
-      font-weight: bold;
+      font-size: var(--wact-sys-typeface-body-large-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
     }
 
     .scoreboard__team-score {
-      font-size: 1.8em;
-      font-weight: bold;
+      font-size: var(--wact-sys-typeface-display-small-size);
+      font-weight: var(--wact-sys-typeface-weight-bold);
       margin-left: auto;
-      transition: color 300ms ease, text-shadow 300ms ease;
+      transition: color var(--wact-sys-motion-duration-medium1) var(--wact-sys-motion-easing-standard), text-shadow var(--wact-sys-motion-duration-medium1) var(--wact-sys-motion-easing-standard);
     }
 
     .scoreboard__team--away .scoreboard__team-score {
@@ -92,13 +89,13 @@ template.innerHTML = `
     }
 
     .scoreboard__team-score--flash {
-      color: var(--sb-flash);
-      text-shadow: 0 0 8px var(--sb-flash);
+      color: var(--wact-comp-scoreboard-possession-color);
+      text-shadow: 0 0 8px var(--wact-comp-scoreboard-possession-color);
     }
 
     #scoreboard__divider {
-      width: 2px;
-      background-color: var(--sb-divider);
+      width: var(--wact-comp-scoreboard-divider-width);
+      background-color: var(--wact-comp-scoreboard-divider-color);
       align-self: stretch;
     }
 
@@ -106,46 +103,46 @@ template.innerHTML = `
       display: flex;
       justify-content: center;
       align-items: center;
-      gap: 16px;
-      padding: 8px 16px;
-      background-color: var(--sb-context-bg);
-      font-size: 0.9em;
-      color: var(--sb-context-text);
-      border-top: 1px solid var(--sb-border);
+      gap: var(--wact-sys-spacing-lg);
+      padding: var(--wact-sys-spacing-sm) var(--wact-sys-spacing-lg);
+      background-color: var(--wact-comp-scoreboard-context-container-color);
+      font-size: var(--wact-sys-typeface-body-medium-size);
+      color: var(--wact-comp-scoreboard-on-context-color);
+      border-top: 1px solid var(--wact-comp-scoreboard-divider-color);
     }
 
     .scoreboard__context-item {
       white-space: nowrap;
-      transition: opacity 150ms ease;
+      transition: opacity var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
     }
 
     #scoreboard__status {
-      font-weight: bold;
-      color: var(--sb-status);
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      color: var(--wact-comp-scoreboard-status-color);
     }
 
     @media only screen and (max-width: 600px) {
       .scoreboard__team {
-        padding: 8px 10px;
-        gap: 8px;
+        padding: var(--wact-sys-spacing-sm) var(--wact-sys-spacing-md);
+        gap: var(--wact-sys-spacing-sm);
       }
 
       .scoreboard__team-logo {
-        width: 28px;
-        height: 28px;
+        width: var(--wact-comp-scoreboard-icon-size);
+        height: var(--wact-comp-scoreboard-icon-size);
       }
 
       .scoreboard__team-name {
-        font-size: 0.9em;
+        font-size: var(--wact-sys-typeface-body-medium-size);
       }
 
       .scoreboard__team-score {
-        font-size: 1.4em;
+        font-size: var(--wact-sys-typeface-title-medium-size);
       }
 
       #scoreboard__context {
-        gap: 8px;
-        font-size: 0.8em;
+        gap: var(--wact-sys-spacing-sm);
+        font-size: var(--wact-sys-typeface-body-small-size);
         flex-wrap: wrap;
       }
     }

--- a/src/components/wact-team-config.ts
+++ b/src/components/wact-team-config.ts
@@ -1,57 +1,80 @@
 import type { TeamConfig } from '../services/types.js';
+import {
+  COLOR_CSS,
+  LAYOUT_CSS,
+  MOTION_CSS,
+  SHAPE_CSS,
+  SPACING_CSS,
+  TYPEFACE_CSS,
+} from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
+    ${COLOR_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+    ${SPACING_CSS}
+    ${TYPEFACE_CSS}
+
     :host {
       display: block;
-      font-family: sans-serif;
-      --tc-bg: #f5f5f5;
-      --tc-text: #333;
-      --tc-label: #666;
-      --tc-input-border: #ccc;
-      --tc-input-color: inherit;
-      --tc-section-header: #333;
-      --tc-error-text: #cc0000;
-      --tc-error-bg: #ffe6e6;
-    }
-
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --tc-bg: #1e1e2e;
-        --tc-text: #e0e0e0;
-        --tc-label: #aaa;
-        --tc-input-border: #555;
-        --tc-input-color: #e0e0e0;
-        --tc-section-header: #ccc;
-        --tc-error-text: #ff6666;
-        --tc-error-bg: #3a1a1a;
-      }
+      font-family: var(--wact-sys-typescale-font-family);
+      --wact-comp-team-config-container-color:            var(--wact-sys-color-surface);
+      --wact-comp-team-config-on-container-color:         var(--wact-sys-color-on-surface);
+      --wact-comp-team-config-label-color:                var(--wact-sys-color-on-surface-muted);
+      --wact-comp-team-config-input-outline-color:        var(--wact-sys-color-outline);
+      --wact-comp-team-config-input-focus-color:          var(--wact-sys-color-primary);
+      --wact-comp-team-config-section-header-color:       var(--wact-sys-color-on-surface);
+      --wact-comp-team-config-section-hover-color:        var(--wact-sys-color-primary);
+      --wact-comp-team-config-error-label-color:          var(--wact-sys-color-error);
+      --wact-comp-team-config-error-container-color:      var(--wact-sys-color-error-container);
+      --wact-comp-team-config-image-shape:                var(--wact-sys-shape-corner-extra-small);
+      --wact-comp-team-config-error-shape:                var(--wact-sys-shape-corner-extra-small);
+      --wact-comp-team-config-container-shape:            var(--wact-sys-shape-corner-medium);
+      --wact-comp-team-config-image-overlay-heavy-color:  var(--wact-sys-color-surface-image-overlay-heavy);
+      --wact-comp-team-config-image-overlay-light-color:  var(--wact-sys-color-surface-image-overlay-light);
+      --wact-comp-team-config-logo-input-bg-color:        var(--wact-sys-color-surface-image-overlay-medium);
+      --wact-comp-team-config-logo-input-on-color:        var(--wact-sys-color-on-image-overlay);
+      --wact-comp-team-config-logo-input-outline-color:   var(--wact-ref-palette-neutral50);
+      --wact-comp-team-config-banner-height:              25vh;
+      --wact-comp-team-config-banner-height-mobile:       20vh;
+      --wact-comp-team-config-z-index-logo:               0;
+      --wact-comp-team-config-z-index-overlay:            1;
+      --wact-comp-team-config-z-index-content:            2;
+      --wact-comp-team-config-row-gap:                    var(--wact-sys-spacing-xs);
+      --wact-comp-team-config-input-padding:              var(--wact-sys-spacing-xs);
+      --wact-comp-team-config-input-font-size:            var(--wact-sys-typescale-body-default-size);
+      --wact-comp-team-config-input-height:               var(--wact-ref-layout-px-32);
+      --wact-comp-team-config-btn-margin-top:             var(--wact-sys-spacing-sm);
+      --wact-comp-team-config-btn-padding:                var(--wact-sys-spacing-lg);
+      --wact-comp-team-config-btn-font-size:              var(--wact-sys-typescale-body-medium-size);
     }
 
     #team-config__wrapper {
-      background-color: var(--tc-bg);
-      border-radius: 8px;
-      padding: 16px;
-      color: var(--tc-text);
+      background-color: var(--wact-comp-team-config-container-color);
+      border-radius: var(--wact-comp-team-config-container-shape);
+      padding: var(--wact-sys-spacing-lg);
+      color: var(--wact-comp-team-config-on-container-color);
     }
 
     #team-config__header-wrapper {
-      width: 100%;
+      width: var(--wact-ref-layout-fit-container);
       display: flex;
       justify-content: space-between;
-      margin-bottom: 8px;
+      margin-bottom: var(--wact-sys-spacing-sm);
     }
 
     #team-config__header-label {
-      font-weight: bold;
-      font-size: 1.5em;
+      font-weight: var(--wact-sys-typescale-weight-bold);
+      font-size: var(--wact-sys-typescale-title-large-size);
     }
 
     .team-config__row {
       display: flex;
-      gap: 8px;
-      margin-bottom: 8px;
+      gap: var(--wact-sys-spacing-sm);
+      margin-bottom: var(--wact-sys-spacing-sm);
     }
 
     .team-config__row > * {
@@ -61,31 +84,31 @@ template.innerHTML = `
     .team-config__input-group {
       display: flex;
       flex-direction: column;
-      margin-bottom: 6px;
+      margin-bottom: var(--wact-sys-spacing-xs);
     }
 
     .team-config__input-group label {
-      font-size: 0.8em;
-      color: var(--tc-label);
-      margin-bottom: 2px;
+      font-size: var(--wact-sys-typescale-body-small-size);
+      color: var(--wact-comp-team-config-label-color);
+      margin-bottom: var(--wact-comp-team-config-row-gap);
     }
 
     .team-config__input-group input[type="text"],
     .team-config__input-group input[type="number"] {
       background-color: rgba(0, 0, 0, 0);
       border: none;
-      border-bottom: 2px solid var(--tc-input-border);
-      padding: 4px 2px;
-      font-size: 1em;
-      color: var(--tc-input-color);
-      transition: border-color 200ms ease;
+      border-bottom: 2px solid var(--wact-comp-team-config-input-outline-color);
+      padding: var(--wact-comp-team-config-input-padding);
+      font-size: var(--wact-comp-team-config-input-font-size);
+      color: inherit;
+      transition: border-color var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     .team-config__input-group input[type="text"]:focus,
     .team-config__input-group input[type="text"]:hover,
     .team-config__input-group input[type="number"]:focus,
     .team-config__input-group input[type="number"]:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-config-input-focus-color);
       outline: none;
     }
 
@@ -96,56 +119,56 @@ template.innerHTML = `
     }
 
     .team-config__input-group input[type="color"] {
-      width: 100%;
-      height: 32px;
+      width: var(--wact-ref-layout-fit-container);
+      height: var(--wact-comp-team-config-input-height);
       padding: 0;
-      border: 2px solid var(--tc-input-border);
-      border-radius: 4px;
+      border: 2px solid var(--wact-comp-team-config-input-outline-color);
+      border-radius: var(--wact-comp-team-config-image-shape);
       cursor: pointer;
       background: none;
     }
 
     .team-config__input-group input[type="color"]:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-config-input-focus-color);
     }
 
     #team-config__image-wrapper {
       position: relative;
-      height: 25vh;
-      transition: all 100ms ease-in-out;
-      margin-bottom: 12px;
-      border-radius: 4px;
+      height: var(--wact-comp-team-config-banner-height);
+      transition: all var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
+      margin-bottom: var(--wact-sys-spacing-md);
+      border-radius: var(--wact-comp-team-config-image-shape);
       overflow: hidden;
     }
 
     #team-config__logo {
-      width: 100%;
-      height: 100%;
+      width: var(--wact-ref-layout-fit-container);
+      height: var(--wact-ref-layout-fit-container);
       object-fit: cover;
       position: absolute;
-      z-index: 0;
+      z-index: var(--wact-comp-team-config-z-index-logo);
     }
 
     #team-config__image-overlay {
       position: absolute;
       top: 0;
       left: 0;
-      width: 100%;
-      height: 100%;
-      z-index: 1;
-      background-color: rgba(0, 0, 0, 0.7);
-      transition: background-color 100ms ease-in-out;
+      width: var(--wact-ref-layout-fit-container);
+      height: var(--wact-ref-layout-fit-container);
+      z-index: var(--wact-comp-team-config-z-index-overlay);
+      background-color: var(--wact-comp-team-config-image-overlay-heavy-color);
+      transition: background-color var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
       pointer-events: none;
     }
 
     #team-config__image-wrapper:hover #team-config__image-overlay {
-      background-color: rgba(0, 0, 0, 0.2);
+      background-color: var(--wact-comp-team-config-image-overlay-light-color);
     }
 
     #team-config__logo-url-wrapper {
-      width: 100%;
+      width: var(--wact-ref-layout-fit-container);
       position: absolute;
-      z-index: 2;
+      z-index: var(--wact-comp-team-config-z-index-content);
       left: 0;
       bottom: 0;
       display: flex;
@@ -153,34 +176,34 @@ template.innerHTML = `
     }
 
     #team-config__logo-url-label {
-      color: white;
-      font-size: 0.9em;
-      margin-left: 4px;
+      color: var(--wact-comp-team-config-logo-input-on-color);
+      font-size: var(--wact-sys-typescale-body-medium-size);
+      margin-left: var(--wact-sys-spacing-xs);
     }
 
     #team-config__logo-url-input {
       flex: 1;
-      background-color: rgba(0, 0, 0, 0.5);
+      background-color: var(--wact-comp-team-config-logo-input-bg-color);
       border: none;
-      border-bottom: 2px solid gray;
-      color: white;
-      padding: 4px;
-      font-size: 0.9em;
-      transition: border-color 200ms ease;
+      border-bottom: 2px solid var(--wact-comp-team-config-logo-input-outline-color);
+      color: var(--wact-comp-team-config-logo-input-on-color);
+      padding: var(--wact-sys-spacing-xs);
+      font-size: var(--wact-sys-typescale-body-medium-size);
+      transition: border-color var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     #team-config__logo-url-input:focus,
     #team-config__logo-url-input:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-config-input-focus-color);
       outline: none;
     }
 
     .team-config__section-header {
-      font-weight: bold;
-      font-size: 1em;
-      margin-top: 12px;
-      margin-bottom: 6px;
-      color: var(--tc-section-header);
+      font-weight: var(--wact-sys-typescale-weight-bold);
+      font-size: var(--wact-sys-typescale-body-default-size);
+      margin-top: var(--wact-sys-spacing-md);
+      margin-bottom: var(--wact-sys-spacing-xs);
+      color: var(--wact-comp-team-config-section-header-color);
       cursor: pointer;
       user-select: none;
       display: flex;
@@ -189,12 +212,12 @@ template.innerHTML = `
     }
 
     .team-config__section-header:hover {
-      color: royalblue;
+      color: var(--wact-comp-team-config-section-hover-color);
     }
 
     .team-config__section-chevron {
-      font-size: 0.7em;
-      transition: transform 200ms ease;
+      font-size: var(--wact-sys-typescale-label-small-size);
+      transition: transform var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     .team-config__section-chevron--collapsed {
@@ -204,7 +227,7 @@ template.innerHTML = `
     .team-config__section-content {
       display: grid;
       grid-template-columns: 1fr 1fr;
-      gap: 4px 12px;
+      gap: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-md);
     }
 
     .team-config__section-content--collapsed {
@@ -212,9 +235,9 @@ template.innerHTML = `
     }
 
     #team-config__load-btn {
-      margin-top: 8px;
-      --btn-padding: 6px 16px;
-      font-size: 0.9em;
+      margin-top: var(--wact-comp-team-config-btn-margin-top);
+      --btn-padding: var(--wact-comp-team-config-btn-padding);
+      font-size: var(--wact-comp-team-config-btn-font-size);
     }
 
     #team-config__file-input {
@@ -223,12 +246,12 @@ template.innerHTML = `
 
     #team-config__error {
       display: none;
-      color: var(--tc-error-text);
-      font-size: 0.85em;
-      margin-top: 6px;
-      padding: 4px 8px;
-      background-color: var(--tc-error-bg);
-      border-radius: 4px;
+      color: var(--wact-comp-team-config-error-label-color);
+      font-size: var(--wact-sys-typescale-body-small-size);
+      margin-top: var(--wact-sys-spacing-xs);
+      padding: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-sm);
+      background-color: var(--wact-comp-team-config-error-container-color);
+      border-radius: var(--wact-comp-team-config-error-shape);
     }
 
     @media only screen and (max-width: 600px) {
@@ -237,7 +260,7 @@ template.innerHTML = `
       }
 
       #team-config__image-wrapper {
-        height: 20vh;
+        height: var(--wact-comp-team-config-banner-height-mobile);
       }
     }
   </style>

--- a/src/components/wact-team-select.ts
+++ b/src/components/wact-team-select.ts
@@ -1,24 +1,33 @@
 import type { TeamInput } from '../services/types.js';
+import { COLOR_CSS, LAYOUT_CSS, MOTION_CSS, TYPEFACE_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
-    :host {
-      --ts-text: #000000;
-      --ts-input-border: black;
-      --ts-input-color: inherit;
-    }
+    ${COLOR_CSS}
+    ${LAYOUT_CSS}
+    ${MOTION_CSS}
+    ${TYPEFACE_CSS}
 
-    @media (prefers-color-scheme: dark) {
-      :host {
-        --ts-text: #e0e0e0;
-        --ts-input-border: #888;
-        --ts-input-color: #e0e0e0;
-      }
+    :host {
+      --wact-comp-team-select-on-surface-color:           var(--wact-sys-color-on-surface);
+      --wact-comp-team-select-input-outline-color:        var(--wact-sys-color-outline);
+      --wact-comp-team-select-input-focus-color:          var(--wact-sys-color-primary);
+      --wact-comp-team-select-image-overlay-heavy-color:  var(--wact-sys-color-surface-image-overlay-heavy);
+      --wact-comp-team-select-image-overlay-light-color:  var(--wact-sys-color-surface-image-overlay-light);
+      --wact-comp-team-select-logo-input-bg-color:        var(--wact-sys-color-surface-image-overlay-medium);
+      --wact-comp-team-select-logo-input-on-color:        var(--wact-sys-color-on-image-overlay);
+      --wact-comp-team-select-logo-input-outline-color:   var(--wact-ref-palette-neutral50);
+      --wact-comp-team-select-banner-height:              var(--wact-ref-layout-vh-40);
+      --wact-comp-team-select-z-index-logo:               var(--wact-sys-layer-neg-1);
+      --wact-comp-team-select-z-index-content:            var(--wact-sys-layer-1);
+      --wact-comp-team-select-input-border-width:         3px;
+      --wact-comp-team-select-input-font-size:            var(--wact-sys-typeface-title-large-size);
+      --wact-comp-team-select-input-bg:                   var(--wact-sys-color-transparent);
     }
 
     #team-select__header-wrapper {
-      width: 100%;
+      width: var(--wact-sys-layout-fit-container);
       display: flex;
       justify-content: space-between;
       margin-top: 1%;
@@ -26,50 +35,50 @@ template.innerHTML = `
     }
 
     #team-select__name-input-label {
-      width: 100%;
-      font-weight: bold;
-      font-size: 2em;
-      color: var(--ts-text);
+      width: var(--wact-sys-layout-fit-container);
+      font-weight: var(--wact-sys-typeface-weight-bold);
+      font-size: var(--wact-sys-typeface-display-medium-size);
+      color: var(--wact-comp-team-select-on-surface-color);
     }
 
     #team-select__name-input {
-      width: 100%;
-      background-color: rgba(0, 0, 0, 0);
+      width: var(--wact-sys-layout-fit-container);
+      background-color: var(--wact-comp-team-select-input-bg);
       border-style: solid;
-      border-width: 0 0 3px 0;
-      transition: all 200ms ease-in-out;
-      border-color: var(--ts-input-border);
-      color: var(--ts-input-color);
-      font-size: 1.5em;
+      border-width: 0 0 var(--wact-comp-team-select-input-border-width) 0;
+      transition: all var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
+      border-color: var(--wact-comp-team-select-input-outline-color);
+      color: inherit;
+      font-size: var(--wact-comp-team-select-input-font-size);
     }
 
     #team-select__name-input:focus, #team-select__name-input:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-select-input-focus-color);
     }
 
     #team-select__image-wrapper {
       position: relative;
-      height: 40vh;
-      background-color: rgba(0, 0, 0, 0.7);
-      transition: all 100ms ease-in-out;
+      height: var(--wact-comp-team-select-banner-height);
+      background-color: var(--wact-comp-team-select-image-overlay-heavy-color);
+      transition: all var(--wact-sys-motion-duration-short1) var(--wact-sys-motion-easing-standard);
     }
 
     #team-select__image-wrapper:hover {
-      background-color: rgba(0, 0, 0, 0.2);
+      background-color: var(--wact-comp-team-select-image-overlay-light-color);
     }
 
     #team-select__logo {
-      width: 100%;
-      height: 100%;
+      width: var(--wact-sys-layout-fit-container);
+      height: var(--wact-sys-layout-fit-container);
       object-fit: cover;
       position: absolute;
-      z-index: -1;
+      z-index: var(--wact-comp-team-select-z-index-logo);
     }
 
     #team-select__logo-url-input-wrapper {
-      width: 100%;
+      width: var(--wact-sys-layout-fit-container);
       position: absolute;
-      z-index: 1;
+      z-index: var(--wact-comp-team-select-z-index-content);
       left: 0;
       bottom: 0;
       display: flex;
@@ -77,29 +86,29 @@ template.innerHTML = `
     }
 
     #team-select__logo-url-input {
-      width: 100%;
-      background-color: rgba(0, 0, 0, 0.5);
+      width: var(--wact-sys-layout-fit-container);
+      background-color: var(--wact-comp-team-select-logo-input-bg-color);
       border-style: solid;
-      border-color: gray;
-      border-width: 0 0 3px 0;
-      transition: all 200ms ease-in-out;
-      color: white;
+      border-color: var(--wact-comp-team-select-logo-input-outline-color);
+      border-width: 0 0 var(--wact-comp-team-select-input-border-width) 0;
+      transition: all var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
+      color: var(--wact-comp-team-select-logo-input-on-color);
       margin-left: 1%;
-      font-size: 1.25em;
+      font-size: var(--wact-sys-typeface-title-small-size);
     }
 
     #team-select__logo-url-input:focus, #team-select__logo-url-input:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-select-input-focus-color);
     }
 
     #team-select__logo-url-input-label {
-      color: white;
-      font-size: 1.25em;
+      color: var(--wact-comp-team-select-logo-input-on-color);
+      font-size: var(--wact-sys-typeface-title-small-size);
       margin-left: 1%;
     }
 
     #team-select__offense-wrapper {
-      width: 100%;
+      width: var(--wact-sys-layout-fit-container);
       display: flex;
       justify-content: space-between;
       margin-top: 1%;
@@ -107,26 +116,26 @@ template.innerHTML = `
     }
 
     #team-select__offense-input-label {
-      font-size: 1.5em;
-      color: var(--ts-text);
+      font-size: var(--wact-sys-typeface-title-large-size);
+      color: var(--wact-comp-team-select-on-surface-color);
     }
 
     #team-select__offense-input {
-      background-color: rgba(0, 0, 0, 0);
+      background-color: var(--wact-comp-team-select-input-bg);
       border-style: solid;
-      border-width: 0 0 3px 0;
-      transition: all 200ms ease-in-out;
-      border-color: var(--ts-input-border);
-      color: var(--ts-input-color);
-      font-size: 1.5em;
+      border-width: 0 0 var(--wact-comp-team-select-input-border-width) 0;
+      transition: all var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
+      border-color: var(--wact-comp-team-select-input-outline-color);
+      color: inherit;
+      font-size: var(--wact-comp-team-select-input-font-size);
     }
 
     #team-select__offense-input:focus, #team-select__offense-input:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-select-input-focus-color);
     }
 
     #team-select__defense-wrapper {
-      width: 100%;
+      width: var(--wact-sys-layout-fit-container);
       display: flex;
       justify-content: space-between;
       margin-top: 1%;
@@ -134,22 +143,22 @@ template.innerHTML = `
     }
 
     #team-select__defense-input-label {
-      font-size: 1.5em;
-      color: var(--ts-text);
+      font-size: var(--wact-sys-typeface-title-large-size);
+      color: var(--wact-comp-team-select-on-surface-color);
     }
 
     #team-select__defense-input {
-      background-color: rgba(0, 0, 0, 0);
+      background-color: var(--wact-comp-team-select-input-bg);
       border-style: solid;
-      border-width: 0 0 3px 0;
-      transition: all 200ms ease-in-out;
-      border-color: var(--ts-input-border);
-      color: var(--ts-input-color);
-      font-size: 1.5em;
+      border-width: 0 0 var(--wact-comp-team-select-input-border-width) 0;
+      transition: all var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
+      border-color: var(--wact-comp-team-select-input-outline-color);
+      color: inherit;
+      font-size: var(--wact-comp-team-select-input-font-size);
     }
 
     #team-select__defense-input:focus, #team-select__defense-input:hover {
-      border-color: royalblue;
+      border-color: var(--wact-comp-team-select-input-focus-color);
     }
   </style>
   <div id="team-select__wrapper" class="team-select__wrapper">

--- a/src/demo/design-tokens.ts
+++ b/src/demo/design-tokens.ts
@@ -1,0 +1,858 @@
+import { DESIGN_TOKENS_CSS } from '../styles/index.js';
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <style>
+    ${DESIGN_TOKENS_CSS}
+
+    :host {
+      display: block;
+      background-color: var(--wact-sys-color-background);
+      color: var(--wact-sys-color-on-background);
+      font-family: var(--wact-sys-typescale-font-family);
+    }
+
+    .dt-page {
+      padding: var(--wact-sys-spacing-2xl);
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+
+    /* ── Section ── */
+    .dt-section {
+      margin-bottom: 48px;
+    }
+
+    .dt-section-title {
+      font-size: var(--wact-sys-typescale-title-medium-size);
+      font-weight: var(--wact-sys-typescale-weight-bold);
+      margin: 0 0 var(--wact-sys-spacing-xs) 0;
+      color: var(--wact-sys-color-on-background);
+    }
+
+    .dt-section-desc {
+      font-size: var(--wact-sys-typescale-body-medium-size);
+      color: var(--wact-sys-color-on-surface-muted);
+      margin: 0 0 var(--wact-sys-spacing-lg) 0;
+    }
+
+    .dt-section-divider {
+      border: none;
+      border-top: 1px solid var(--wact-sys-color-outline);
+      margin: 0 0 var(--wact-sys-spacing-lg) 0;
+    }
+
+    .dt-family-title {
+      font-size: var(--wact-sys-typescale-body-medium-size);
+      font-weight: var(--wact-sys-typescale-weight-bold);
+      color: var(--wact-sys-color-on-surface-variant);
+      margin: var(--wact-sys-spacing-lg) 0 var(--wact-sys-spacing-sm) 0;
+    }
+
+    /* ── Palette swatches ── */
+    .dt-swatch-strip {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wact-sys-spacing-sm);
+    }
+
+    .dt-swatch {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--wact-sys-spacing-xs);
+      width: 64px;
+    }
+
+    .dt-swatch-color {
+      width: 64px;
+      height: 52px;
+      border-radius: var(--wact-sys-shape-corner-small);
+      border: 1px solid var(--wact-sys-color-outline-variant);
+    }
+
+    .dt-swatch-name {
+      font-size: 0.65em;
+      color: var(--wact-sys-color-on-surface-muted);
+      text-align: center;
+      font-family: monospace;
+      line-height: 1.3;
+      word-break: break-word;
+    }
+
+    /* ── System color roles ── */
+    .dt-color-groups {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+      gap: var(--wact-sys-spacing-xl);
+    }
+
+    .dt-color-group-title {
+      font-size: var(--wact-sys-typescale-body-small-size);
+      font-weight: var(--wact-sys-typescale-weight-bold);
+      color: var(--wact-sys-color-on-surface-variant);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      margin: 0 0 var(--wact-sys-spacing-sm) 0;
+    }
+
+    .dt-color-role-list {
+      display: flex;
+      flex-direction: column;
+      gap: var(--wact-sys-spacing-xs);
+    }
+
+    .dt-color-role {
+      display: flex;
+      align-items: center;
+      gap: var(--wact-sys-spacing-sm);
+    }
+
+    .dt-color-role-swatch {
+      width: 36px;
+      height: 36px;
+      border-radius: var(--wact-sys-shape-corner-extra-small);
+      border: 1px solid var(--wact-sys-color-outline-variant);
+      flex-shrink: 0;
+    }
+
+    .dt-color-role-info {
+      min-width: 0;
+    }
+
+    .dt-color-role-name {
+      font-size: 0.68em;
+      color: var(--wact-sys-color-on-surface);
+      font-family: monospace;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    /* ── Typography ── */
+    .dt-type-scale {
+      display: flex;
+      flex-direction: column;
+      gap: var(--wact-sys-spacing-md);
+    }
+
+    .dt-type-row {
+      display: grid;
+      grid-template-columns: 240px 1fr;
+      align-items: baseline;
+      gap: var(--wact-sys-spacing-lg);
+      padding-bottom: var(--wact-sys-spacing-md);
+      border-bottom: 1px solid var(--wact-sys-color-outline-variant);
+    }
+
+    .dt-type-row:last-child {
+      border-bottom: none;
+    }
+
+    .dt-type-meta {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .dt-type-token {
+      font-size: 0.68em;
+      font-family: monospace;
+      color: var(--wact-sys-color-on-surface-muted);
+    }
+
+    .dt-type-value {
+      font-size: 0.68em;
+      font-family: monospace;
+      color: var(--wact-sys-color-tertiary-status);
+    }
+
+    .dt-type-sample {
+      color: var(--wact-sys-color-on-background);
+    }
+
+    /* font-family & weight rows */
+    .dt-type-row--baseline {
+      align-items: center;
+    }
+
+    /* ── Shape ── */
+    .dt-shapes {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wact-sys-spacing-2xl);
+      align-items: flex-end;
+    }
+
+    .dt-shape {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--wact-sys-spacing-sm);
+    }
+
+    .dt-shape-box {
+      width: 80px;
+      height: 80px;
+      background: var(--wact-sys-color-primary);
+    }
+
+    .dt-shape-label {
+      font-size: 0.68em;
+      color: var(--wact-sys-color-on-surface-muted);
+      font-family: monospace;
+      text-align: center;
+    }
+
+    /* ── Motion ── */
+    .dt-motion-rows {
+      display: flex;
+      flex-direction: column;
+      gap: var(--wact-sys-spacing-md);
+    }
+
+    .dt-motion-row {
+      display: grid;
+      grid-template-columns: 300px 1fr;
+      align-items: center;
+      gap: var(--wact-sys-spacing-lg);
+    }
+
+    .dt-motion-label {
+      font-size: 0.68em;
+      font-family: monospace;
+      color: var(--wact-sys-color-on-surface-muted);
+    }
+
+    .dt-motion-track {
+      height: 10px;
+      background: var(--wact-sys-color-surface-recessed);
+      border-radius: var(--wact-sys-shape-corner-full);
+      overflow: hidden;
+    }
+
+    .dt-motion-fill {
+      height: 100%;
+      background: var(--wact-sys-color-primary);
+      border-radius: var(--wact-sys-shape-corner-full);
+      animation-name: dt-fill;
+      animation-iteration-count: infinite;
+      animation-direction: alternate;
+    }
+
+    @keyframes dt-fill {
+      from { width: 5%; }
+      to   { width: 95%; }
+    }
+
+    /* Motion duration classes */
+    .dt-fill--short1-std  { animation-duration: var(--wact-sys-motion-duration-short1);  animation-timing-function: var(--wact-sys-motion-easing-standard); }
+    .dt-fill--short2-std  { animation-duration: var(--wact-sys-motion-duration-short2);  animation-timing-function: var(--wact-sys-motion-easing-standard); }
+    .dt-fill--medium1-std { animation-duration: var(--wact-sys-motion-duration-medium1); animation-timing-function: var(--wact-sys-motion-easing-standard); }
+    .dt-fill--medium2-std { animation-duration: var(--wact-sys-motion-duration-medium2); animation-timing-function: var(--wact-sys-motion-easing-standard); }
+    .dt-fill--short1-lin  { animation-duration: var(--wact-sys-motion-duration-short1);  animation-timing-function: var(--wact-sys-motion-easing-linear); }
+    .dt-fill--medium1-lin { animation-duration: var(--wact-sys-motion-duration-medium1); animation-timing-function: var(--wact-sys-motion-easing-linear); }
+
+    /* ── Elevation ── */
+    .dt-elevations {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wact-sys-spacing-2xl);
+      align-items: center;
+    }
+
+    .dt-elevation {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--wact-sys-spacing-sm);
+    }
+
+    .dt-elevation-card {
+      width: 120px;
+      height: 72px;
+      background: var(--wact-sys-color-surface);
+      border-radius: var(--wact-sys-shape-corner-medium);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: var(--wact-sys-typescale-label-medium-size);
+      color: var(--wact-sys-color-on-surface-muted);
+    }
+
+    .dt-elevation-card--0    { box-shadow: none; }
+    .dt-elevation-card--1    { box-shadow: var(--wact-sys-elevation-level1); }
+    .dt-elevation-card--2    { box-shadow: var(--wact-sys-elevation-level2); }
+
+    .dt-elevation-label {
+      font-size: 0.68em;
+      color: var(--wact-sys-color-on-surface-muted);
+      font-family: monospace;
+      text-align: center;
+    }
+
+    /* ── State layers ── */
+    .dt-states {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--wact-sys-spacing-2xl);
+    }
+
+    .dt-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--wact-sys-spacing-sm);
+    }
+
+    .dt-state-block {
+      width: 80px;
+      height: 80px;
+      background: var(--wact-sys-color-primary);
+      border-radius: var(--wact-sys-shape-corner-medium);
+    }
+
+    .dt-state-block--full     { opacity: 1; }
+    .dt-state-block--inactive { opacity: var(--wact-sys-state-layer-opacity-inactive); }
+    .dt-state-block--disabled { opacity: var(--wact-sys-state-layer-opacity-disabled); }
+
+    .dt-state-label {
+      font-size: 0.68em;
+      color: var(--wact-sys-color-on-surface-muted);
+      font-family: monospace;
+      text-align: center;
+    }
+
+    /* ── Spacing ── */
+    .dt-spacings {
+      display: flex;
+      flex-direction: column;
+      gap: var(--wact-sys-spacing-sm);
+    }
+
+    .dt-spacing-row {
+      display: grid;
+      grid-template-columns: 200px 1fr;
+      align-items: center;
+      gap: var(--wact-sys-spacing-lg);
+    }
+
+    .dt-spacing-label {
+      font-size: 0.68em;
+      font-family: monospace;
+      color: var(--wact-sys-color-on-surface-muted);
+    }
+
+    .dt-spacing-track {
+      height: 20px;
+      background: var(--wact-sys-color-surface-recessed);
+      border-radius: var(--wact-sys-shape-corner-small);
+      overflow: hidden;
+    }
+
+    .dt-spacing-bar {
+      height: 100%;
+      background: var(--wact-sys-color-interactive-active);
+      border-radius: var(--wact-sys-shape-corner-small);
+    }
+
+    .dt-spacing-bar--xs  { width: var(--wact-sys-spacing-xs);  }
+    .dt-spacing-bar--sm  { width: var(--wact-sys-spacing-sm);  }
+    .dt-spacing-bar--md  { width: var(--wact-sys-spacing-md);  }
+    .dt-spacing-bar--lg  { width: var(--wact-sys-spacing-lg);  }
+    .dt-spacing-bar--xl  { width: var(--wact-sys-spacing-xl);  }
+    .dt-spacing-bar--2xl { width: var(--wact-sys-spacing-2xl); }
+  </style>
+  <div class="dt-page">
+
+    <!-- ═══════════════════════════════════════════════════════════
+         REFERENCE PALETTE
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">Reference Palette</h2>
+      <p class="dt-section-desc">Raw palette values — mode-independent constants that underpin all semantic tokens. These are never used directly in components.</p>
+      <hr class="dt-section-divider">
+
+      <p class="dt-family-title">Primary (navy → white blue)</p>
+      <div class="dt-swatch-strip">
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary5)"></div><div class="dt-swatch-name">primary5</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary10)"></div><div class="dt-swatch-name">primary10</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary17)"></div><div class="dt-swatch-name">primary17</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary20)"></div><div class="dt-swatch-name">primary20</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary23)"></div><div class="dt-swatch-name">primary23</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary28)"></div><div class="dt-swatch-name">primary28</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary30)"></div><div class="dt-swatch-name">primary30</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary32)"></div><div class="dt-swatch-name">primary32</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary35)"></div><div class="dt-swatch-name">primary35</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary37)"></div><div class="dt-swatch-name">primary37</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary40)"></div><div class="dt-swatch-name">primary40</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary43)"></div><div class="dt-swatch-name">primary43</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary45)"></div><div class="dt-swatch-name">primary45</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary47)"></div><div class="dt-swatch-name">primary47</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary50)"></div><div class="dt-swatch-name">primary50</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary60)"></div><div class="dt-swatch-name">primary60</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary79)"></div><div class="dt-swatch-name">primary79</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary82)"></div><div class="dt-swatch-name">primary82</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary84)"></div><div class="dt-swatch-name">primary84</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary88)"></div><div class="dt-swatch-name">primary88</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary91)"></div><div class="dt-swatch-name">primary91</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary93)"></div><div class="dt-swatch-name">primary93</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary95)"></div><div class="dt-swatch-name">primary95</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-primary99)"></div><div class="dt-swatch-name">primary99</div></div>
+      </div>
+
+      <p class="dt-family-title">Neutral (pure grays)</p>
+      <div class="dt-swatch-strip">
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral16)"></div><div class="dt-swatch-name">neutral16</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral20)"></div><div class="dt-swatch-name">neutral20</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral22)"></div><div class="dt-swatch-name">neutral22</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral27)"></div><div class="dt-swatch-name">neutral27</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral34)"></div><div class="dt-swatch-name">neutral34</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral40)"></div><div class="dt-swatch-name">neutral40</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral60)"></div><div class="dt-swatch-name">neutral60</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral74)"></div><div class="dt-swatch-name">neutral74</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral75)"></div><div class="dt-swatch-name">neutral75</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral80)"></div><div class="dt-swatch-name">neutral80</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral83)"></div><div class="dt-swatch-name">neutral83</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-neutral100)"></div><div class="dt-swatch-name">neutral100</div></div>
+      </div>
+
+      <p class="dt-family-title">Error (reds)</p>
+      <div class="dt-swatch-strip">
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error10)"></div><div class="dt-swatch-name">error10</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error20)"></div><div class="dt-swatch-name">error20</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error25)"></div><div class="dt-swatch-name">error25</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error30)"></div><div class="dt-swatch-name">error30</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error38)"></div><div class="dt-swatch-name">error38</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error40)"></div><div class="dt-swatch-name">error40</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error70)"></div><div class="dt-swatch-name">error70</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-error90)"></div><div class="dt-swatch-name">error90</div></div>
+      </div>
+
+      <p class="dt-family-title">Tertiary (gold)</p>
+      <div class="dt-swatch-strip">
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-tertiary36)"></div><div class="dt-swatch-name">tertiary36</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-tertiary40)"></div><div class="dt-swatch-name">tertiary40</div></div>
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-tertiary82)"></div><div class="dt-swatch-name">tertiary82</div></div>
+      </div>
+
+      <p class="dt-family-title">Field</p>
+      <div class="dt-swatch-strip">
+        <div class="dt-swatch"><div class="dt-swatch-color" style="background:var(--wact-ref-palette-field40)"></div><div class="dt-swatch-name">field40</div></div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         SYSTEM COLORS
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">System Colors</h2>
+      <p class="dt-section-desc">Semantic color roles that adapt to the current color scheme (light / dark). Swatches reflect the active mode.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-color-groups">
+
+        <!-- Navigation -->
+        <div>
+          <p class="dt-color-group-title">Navigation</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-nav)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-nav</div></div></div>
+          </div>
+        </div>
+
+        <!-- Page / Background -->
+        <div>
+          <p class="dt-color-group-title">Page / Background</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-background)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-background</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-background)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-background</div></div></div>
+          </div>
+        </div>
+
+        <!-- Surface -->
+        <div>
+          <p class="dt-color-group-title">Surface</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-surface)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-surface</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-surface-raised)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-surface-raised</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-surface-recessed)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-surface-recessed</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-surface-container-hover)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-surface-container-hover</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-surface)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-surface</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-surface-variant)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-surface-variant</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-surface-muted)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-surface-muted</div></div></div>
+          </div>
+        </div>
+
+        <!-- Interactive -->
+        <div>
+          <p class="dt-color-group-title">Interactive</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-interactive)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-interactive</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-interactive-hover)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-interactive-hover</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-interactive-active)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-interactive-active</div></div></div>
+          </div>
+        </div>
+
+        <!-- Primary -->
+        <div>
+          <p class="dt-color-group-title">Primary</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-primary)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-primary</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-primary-hover)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-primary-hover</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-primary-active)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-primary-active</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-primary)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-primary</div></div></div>
+          </div>
+        </div>
+
+        <!-- Tertiary -->
+        <div>
+          <p class="dt-color-group-title">Tertiary</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-tertiary)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-tertiary</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-tertiary-status)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-tertiary-status</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-tertiary)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-tertiary</div></div></div>
+          </div>
+        </div>
+
+        <!-- Destructive -->
+        <div>
+          <p class="dt-color-group-title">Destructive</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-destructive)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-destructive</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-destructive-hover)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-destructive-hover</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-destructive-active)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-destructive-active</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-destructive)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-destructive</div></div></div>
+          </div>
+        </div>
+
+        <!-- Error -->
+        <div>
+          <p class="dt-color-group-title">Error</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-error)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-error</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-error-container)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-error-container</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-error-container)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-error-container</div></div></div>
+          </div>
+        </div>
+
+        <!-- Outline -->
+        <div>
+          <p class="dt-color-group-title">Outline</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-outline)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-outline</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-outline-variant)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-outline-variant</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-outline-field)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-outline-field</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-outline-card)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-outline-card</div></div></div>
+          </div>
+        </div>
+
+        <!-- Feedback -->
+        <div>
+          <p class="dt-color-group-title">Feedback</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-feedback)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-feedback</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-feedback-progress)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-feedback-progress</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-feedback-accent)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-feedback-accent</div></div></div>
+          </div>
+        </div>
+
+        <!-- Tooltip & Overlay -->
+        <div>
+          <p class="dt-color-group-title">Tooltip &amp; Overlay</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-tooltip-container)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-tooltip-container</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-on-tooltip)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-on-tooltip</div></div></div>
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-overlay)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-overlay</div></div></div>
+          </div>
+        </div>
+
+        <!-- Field -->
+        <div>
+          <p class="dt-color-group-title">Field</p>
+          <div class="dt-color-role-list">
+            <div class="dt-color-role"><div class="dt-color-role-swatch" style="background:var(--wact-sys-color-field)"></div><div class="dt-color-role-info"><div class="dt-color-role-name">--wact-sys-color-field</div></div></div>
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         TYPOGRAPHY
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">Typography</h2>
+      <p class="dt-section-desc">Type scale — font family, weights, and size ramp. All sizes are relative (em) so they scale with the host font.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-type-scale">
+
+        <!-- font-family -->
+        <div class="dt-type-row dt-type-row--baseline">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-font-family</div>
+            <div class="dt-type-value">sans-serif</div>
+          </div>
+          <div class="dt-type-sample" style="font-family:var(--wact-sys-typescale-font-family)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <!-- weights -->
+        <div class="dt-type-row dt-type-row--baseline">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-weight-normal</div>
+            <div class="dt-type-value">normal</div>
+          </div>
+          <div class="dt-type-sample" style="font-weight:var(--wact-sys-typescale-weight-normal)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row dt-type-row--baseline">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-weight-bold</div>
+            <div class="dt-type-value">bold</div>
+          </div>
+          <div class="dt-type-sample" style="font-weight:var(--wact-sys-typescale-weight-bold)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <!-- sizes -->
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-label-small-size</div>
+            <div class="dt-type-value">0.7em — field labels</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-label-small-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-label-medium-size</div>
+            <div class="dt-type-value">0.75em — tooltips, metadata</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-label-medium-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-body-small-size</div>
+            <div class="dt-type-value">0.85em — error messages</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-body-small-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-body-medium-size</div>
+            <div class="dt-type-value">0.9em — secondary body, play descriptions</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-body-medium-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-body-default-size</div>
+            <div class="dt-type-value">1em — standard body</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-body-default-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-body-large-size</div>
+            <div class="dt-type-value">1.1em — scoreboard team names</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-body-large-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-title-small-size</div>
+            <div class="dt-type-value">1.2em — final score line</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-title-small-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-title-medium-size</div>
+            <div class="dt-type-value">1.4em — mode card titles</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-title-medium-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+        <div class="dt-type-row">
+          <div class="dt-type-meta">
+            <div class="dt-type-token">--wact-sys-typescale-title-large-size</div>
+            <div class="dt-type-value">1.5em — start button, postgame winner</div>
+          </div>
+          <div class="dt-type-sample" style="font-size:var(--wact-sys-typescale-title-large-size)">The quick brown fox jumps over the lazy dog.</div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         SHAPE
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">Shape</h2>
+      <p class="dt-section-desc">Corner radius scale following MD3 naming. Used for buttons, cards, tooltips, and container shapes.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-shapes">
+        <div class="dt-shape">
+          <div class="dt-shape-box" style="border-radius:var(--wact-sys-shape-corner-extra-small)"></div>
+          <div class="dt-shape-label">extra-small<br>4px</div>
+        </div>
+        <div class="dt-shape">
+          <div class="dt-shape-box" style="border-radius:var(--wact-sys-shape-corner-small)"></div>
+          <div class="dt-shape-label">small<br>6px</div>
+        </div>
+        <div class="dt-shape">
+          <div class="dt-shape-box" style="border-radius:var(--wact-sys-shape-corner-medium)"></div>
+          <div class="dt-shape-label">medium<br>8px</div>
+        </div>
+        <div class="dt-shape">
+          <div class="dt-shape-box" style="border-radius:var(--wact-sys-shape-corner-large)"></div>
+          <div class="dt-shape-label">large<br>12px</div>
+        </div>
+        <div class="dt-shape">
+          <div class="dt-shape-box" style="border-radius:var(--wact-sys-shape-corner-full)"></div>
+          <div class="dt-shape-label">full<br>50%</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         MOTION
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">Motion</h2>
+      <p class="dt-section-desc">Duration and easing tokens. Each bar animates using the specified duration and easing — faster bars use shorter durations.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-motion-rows">
+        <div class="dt-motion-row">
+          <div class="dt-motion-label">--wact-sys-motion-duration-short1 · easing-standard<br>(150ms · ease)</div>
+          <div class="dt-motion-track"><div class="dt-motion-fill dt-fill--short1-std"></div></div>
+        </div>
+        <div class="dt-motion-row">
+          <div class="dt-motion-label">--wact-sys-motion-duration-short1 · easing-linear<br>(150ms · linear)</div>
+          <div class="dt-motion-track"><div class="dt-motion-fill dt-fill--short1-lin"></div></div>
+        </div>
+        <div class="dt-motion-row">
+          <div class="dt-motion-label">--wact-sys-motion-duration-short2 · easing-standard<br>(200ms · ease)</div>
+          <div class="dt-motion-track"><div class="dt-motion-fill dt-fill--short2-std"></div></div>
+        </div>
+        <div class="dt-motion-row">
+          <div class="dt-motion-label">--wact-sys-motion-duration-medium1 · easing-standard<br>(300ms · ease)</div>
+          <div class="dt-motion-track"><div class="dt-motion-fill dt-fill--medium1-std"></div></div>
+        </div>
+        <div class="dt-motion-row">
+          <div class="dt-motion-label">--wact-sys-motion-duration-medium1 · easing-linear<br>(300ms · linear)</div>
+          <div class="dt-motion-track"><div class="dt-motion-fill dt-fill--medium1-lin"></div></div>
+        </div>
+        <div class="dt-motion-row">
+          <div class="dt-motion-label">--wact-sys-motion-duration-medium2 · easing-standard<br>(400ms · ease)</div>
+          <div class="dt-motion-track"><div class="dt-motion-fill dt-fill--medium2-std"></div></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         ELEVATION
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">Elevation</h2>
+      <p class="dt-section-desc">Box shadow levels used for menus, dropdowns, and feedback ribbons.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-elevations">
+        <div class="dt-elevation">
+          <div class="dt-elevation-card dt-elevation-card--0">No shadow</div>
+          <div class="dt-elevation-label">level0 (none)</div>
+        </div>
+        <div class="dt-elevation">
+          <div class="dt-elevation-card dt-elevation-card--1">Level 1</div>
+          <div class="dt-elevation-label">--wact-sys-elevation-level1<br>menus &amp; dropdowns</div>
+        </div>
+        <div class="dt-elevation">
+          <div class="dt-elevation-card dt-elevation-card--2">Level 2</div>
+          <div class="dt-elevation-label">--wact-sys-elevation-level2<br>feedback ribbon</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         STATE LAYERS
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">State Layers</h2>
+      <p class="dt-section-desc">Opacity values applied to elements in disabled or inactive states.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-states">
+        <div class="dt-state">
+          <div class="dt-state-block dt-state-block--full"></div>
+          <div class="dt-state-label">opacity: 1<br>(active)</div>
+        </div>
+        <div class="dt-state">
+          <div class="dt-state-block dt-state-block--inactive"></div>
+          <div class="dt-state-label">--wact-sys-state-layer-opacity-inactive<br>0.45</div>
+        </div>
+        <div class="dt-state">
+          <div class="dt-state-block dt-state-block--disabled"></div>
+          <div class="dt-state-label">--wact-sys-state-layer-opacity-disabled<br>0.4</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ═══════════════════════════════════════════════════════════
+         SPACING
+    ═══════════════════════════════════════════════════════════ -->
+    <section class="dt-section">
+      <h2 class="dt-section-title">Spacing</h2>
+      <p class="dt-section-desc">4px-grid spacing scale. Bar widths are proportional to the token value.</p>
+      <hr class="dt-section-divider">
+
+      <div class="dt-spacings">
+        <div class="dt-spacing-row">
+          <div class="dt-spacing-label">--wact-sys-spacing-xs · 4px</div>
+          <div class="dt-spacing-track"><div class="dt-spacing-bar dt-spacing-bar--xs"></div></div>
+        </div>
+        <div class="dt-spacing-row">
+          <div class="dt-spacing-label">--wact-sys-spacing-sm · 8px</div>
+          <div class="dt-spacing-track"><div class="dt-spacing-bar dt-spacing-bar--sm"></div></div>
+        </div>
+        <div class="dt-spacing-row">
+          <div class="dt-spacing-label">--wact-sys-spacing-md · 12px</div>
+          <div class="dt-spacing-track"><div class="dt-spacing-bar dt-spacing-bar--md"></div></div>
+        </div>
+        <div class="dt-spacing-row">
+          <div class="dt-spacing-label">--wact-sys-spacing-lg · 16px</div>
+          <div class="dt-spacing-track"><div class="dt-spacing-bar dt-spacing-bar--lg"></div></div>
+        </div>
+        <div class="dt-spacing-row">
+          <div class="dt-spacing-label">--wact-sys-spacing-xl · 20px</div>
+          <div class="dt-spacing-track"><div class="dt-spacing-bar dt-spacing-bar--xl"></div></div>
+        </div>
+        <div class="dt-spacing-row">
+          <div class="dt-spacing-label">--wact-sys-spacing-2xl · 40px</div>
+          <div class="dt-spacing-track"><div class="dt-spacing-bar dt-spacing-bar--2xl"></div></div>
+        </div>
+      </div>
+    </section>
+
+  </div>
+`;
+
+class WACTDesignTokens extends HTMLElement {
+  static readonly tagName = 'wact-design-tokens' as const;
+
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' }).append(template.content.cloneNode(true));
+  }
+}
+
+if (!customElements.get(WACTDesignTokens.tagName)) {
+  customElements.define(WACTDesignTokens.tagName, WACTDesignTokens);
+}

--- a/src/demo/wact-button.ts
+++ b/src/demo/wact-button.ts
@@ -1,0 +1,29 @@
+import '../register.js';
+import type { WACTButton } from '../components/wact-button.js';
+
+await customElements.whenDefined('wact-button');
+
+function wireLoadingDemo(
+  id: string,
+  confirmText?: string,
+  duration?: number,
+  delayMs = 2000,
+): void {
+  const btn = document.getElementById(id) as WACTButton | null;
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    btn.startLoading();
+    setTimeout(() => {
+      btn.stopLoading(confirmText, duration);
+    }, delayMs);
+  });
+}
+
+wireLoadingDemo('btn-load-reset');
+wireLoadingDemo('btn-load-confirm', 'Saved!');
+wireLoadingDemo('btn-load-confirm-long', 'Done!', 5000);
+wireLoadingDemo('btn-load-hold', 'Confirm held', 0);
+
+const resetBtn = document.getElementById('btn-manual-reset') as WACTButton | null;
+const holdBtn = document.getElementById('btn-load-hold') as WACTButton | null;
+resetBtn?.addEventListener('click', () => holdBtn?.reset());

--- a/src/styles/color.ts
+++ b/src/styles/color.ts
@@ -1,0 +1,242 @@
+const REF_COLOR_CSS = `
+:host {
+  /* Primary family (navy-to-white blue) */
+  --wact-ref-palette-primary5:  #020210;
+  --wact-ref-palette-primary10: #11111f;
+  --wact-ref-palette-primary17: #16213e;
+  --wact-ref-palette-primary20: #1a1a2e;
+  --wact-ref-palette-primary23: #22223a;
+  --wact-ref-palette-primary28: #162267;
+  --wact-ref-palette-primary30: #2c4494;
+  --wact-ref-palette-primary32: #2f2f3f;
+  --wact-ref-palette-primary35: #3c54a4;
+  --wact-ref-palette-primary37: #3a3a4e;
+  --wact-ref-palette-primary40: #3a58b0;
+  --wact-ref-palette-primary43: #3f3f4f;
+  --wact-ref-palette-primary45: #4c64b4;
+  --wact-ref-palette-primary47: #4f4f5f;
+  --wact-ref-palette-primary50: #4a68c0;
+  --wact-ref-palette-primary60: #5a78d0;
+  --wact-ref-palette-primary79: #b8bce0;
+  --wact-ref-palette-primary82: #d0d0d8;
+  --wact-ref-palette-primary84: #cfd2e8;
+  --wact-ref-palette-primary88: #dde0ed;
+  --wact-ref-palette-primary91: #e8eaf6;
+  --wact-ref-palette-primary93: #e8e8f0;
+  --wact-ref-palette-primary95: #f0f0f5;
+  --wact-ref-palette-primary99: #ffffff;
+
+  /* Neutral family (pure grays) */
+  --wact-ref-palette-neutral16:  #282828;
+  --wact-ref-palette-neutral20:  #333333;
+  --wact-ref-palette-neutral22:  #383838;
+  --wact-ref-palette-neutral27:  #444444;
+  --wact-ref-palette-neutral34:  #555555;
+  --wact-ref-palette-neutral40:  #666666;
+  --wact-ref-palette-neutral50:  #808080;
+  --wact-ref-palette-neutral60:  #999999;
+  --wact-ref-palette-neutral74:  #bbbbbb;
+  --wact-ref-palette-neutral75:  #c0c0c0;
+  --wact-ref-palette-neutral80:  #cccccc;
+  --wact-ref-palette-neutral83:  #d3d3d3;
+  --wact-ref-palette-neutral100: #ffffff;
+
+  /* Error family (reds) */
+  --wact-ref-palette-error10: #3a1a1a;
+  --wact-ref-palette-error20: #800000;
+  --wact-ref-palette-error25: #8b0000;
+  --wact-ref-palette-error30: #a00000;
+  --wact-ref-palette-error38: #c00000;
+  --wact-ref-palette-error40: #cc0000;
+  --wact-ref-palette-error70: #ff6666;
+  --wact-ref-palette-error90: #ffe6e6;
+
+  /* Tertiary family (gold/yellow) */
+  --wact-ref-palette-tertiary36: #b8860b;
+  --wact-ref-palette-tertiary40: #c5a200;
+  --wact-ref-palette-tertiary82: #ffd700;
+
+  /* Field family (green turf & on-field elements) */
+  --wact-ref-palette-field40:      #2d7a2d;
+  --wact-ref-palette-field-on:     rgba(255, 255, 255, 0.60);
+  --wact-ref-palette-field-line:   rgba(255, 255, 255, 0.30);
+  --wact-ref-palette-field-label:  rgba(255, 255, 255, 0.50);
+
+  /* Ball family (football) */
+  --wact-ref-palette-ball60:       #8b4513;
+  --wact-ref-palette-ball-outline: #ffffff;
+
+  /* Overlay family (transparent / black semi-transparent) */
+  --wact-ref-palette-transparent0:  transparent;
+  --wact-ref-palette-transparent20: rgba(0, 0, 0, 0.20);
+  --wact-ref-palette-transparent50: rgba(0, 0, 0, 0.50);
+  --wact-ref-palette-transparent70: rgba(0, 0, 0, 0.70);
+
+  /* Result family (win / lose / tie states) */
+  --wact-ref-palette-success-overlay: rgba(0,  63,  0,  0.70);
+  --wact-ref-palette-success-border:  #00ff00;
+  --wact-ref-palette-defeat-overlay:  rgba(63,  0,  0,  0.70);
+  --wact-ref-palette-defeat-border:   #ff0000;
+}
+`;
+
+const SYS_COLOR_CSS = `
+:host {
+  /* Navigation */
+  --wact-sys-color-nav:                            var(--wact-ref-palette-primary28);
+
+  /* Page / Background */
+  --wact-sys-color-background:                     var(--wact-ref-palette-primary99);
+  --wact-sys-color-on-background:                  var(--wact-ref-palette-primary20);
+
+  /* Surface */
+  --wact-sys-color-surface:                        var(--wact-ref-palette-primary95);
+  --wact-sys-color-surface-raised:                 var(--wact-ref-palette-primary91);
+  --wact-sys-color-surface-recessed:               var(--wact-ref-palette-primary84);
+  --wact-sys-color-surface-container-hover:        var(--wact-ref-palette-primary93);
+  --wact-sys-color-on-surface:                     var(--wact-ref-palette-primary20);
+  --wact-sys-color-on-surface-variant:             var(--wact-ref-palette-neutral34);
+  --wact-sys-color-on-surface-muted:               var(--wact-ref-palette-neutral60);
+
+  /* Image / logo overlays */
+  --wact-sys-color-surface-image-overlay-heavy:    var(--wact-ref-palette-transparent70);
+  --wact-sys-color-surface-image-overlay-medium:   var(--wact-ref-palette-transparent50);
+  --wact-sys-color-surface-image-overlay-light:    var(--wact-ref-palette-transparent20);
+  --wact-sys-color-on-image-overlay:               var(--wact-ref-palette-primary99);
+
+  /* Interactive (neutral buttons, speed controls) */
+  --wact-sys-color-interactive:                    var(--wact-ref-palette-primary88);
+  --wact-sys-color-interactive-hover:              var(--wact-ref-palette-primary84);
+  --wact-sys-color-interactive-active:             var(--wact-ref-palette-primary79);
+
+  /* Primary action (accent buttons) */
+  --wact-sys-color-primary:                        var(--wact-ref-palette-primary40);
+  --wact-sys-color-primary-hover:                  var(--wact-ref-palette-primary50);
+  --wact-sys-color-primary-active:                 var(--wact-ref-palette-primary60);
+  --wact-sys-color-on-primary:                     var(--wact-ref-palette-primary99);
+
+  /* Tertiary (gold/highlight/possession) */
+  --wact-sys-color-tertiary:                       var(--wact-ref-palette-tertiary40);
+  --wact-sys-color-tertiary-status:                var(--wact-ref-palette-tertiary36);
+  --wact-sys-color-on-tertiary:                    var(--wact-ref-palette-primary20);
+
+  /* Destructive */
+  --wact-sys-color-destructive:                    var(--wact-ref-palette-error40);
+  --wact-sys-color-destructive-hover:              var(--wact-ref-palette-error30);
+  --wact-sys-color-destructive-active:             var(--wact-ref-palette-error20);
+  --wact-sys-color-on-destructive:                 var(--wact-ref-palette-primary99);
+
+  /* Error */
+  --wact-sys-color-error:                          var(--wact-ref-palette-error40);
+  --wact-sys-color-error-container:                var(--wact-ref-palette-error90);
+  --wact-sys-color-on-error-container:             var(--wact-ref-palette-error40);
+
+  /* Outline / Borders */
+  --wact-sys-color-outline:                        var(--wact-ref-palette-neutral80);
+  --wact-sys-color-outline-variant:                var(--wact-ref-palette-neutral74);
+  --wact-sys-color-outline-field:                  var(--wact-ref-palette-neutral60);
+  --wact-sys-color-outline-card:                   var(--wact-ref-palette-primary82);
+
+  /* Feedback Ribbon */
+  --wact-sys-color-feedback:                       var(--wact-ref-palette-neutral83);
+  --wact-sys-color-feedback-progress:              var(--wact-ref-palette-neutral75);
+  --wact-sys-color-feedback-accent:                var(--wact-ref-palette-error38);
+
+  /* Tooltip */
+  --wact-sys-color-tooltip-container:              var(--wact-ref-palette-neutral34);
+  --wact-sys-color-on-tooltip:                     var(--wact-ref-palette-primary99);
+
+  /* Overlay (generic dark scrim) */
+  --wact-sys-color-overlay:                        var(--wact-ref-palette-transparent70);
+
+  /* Field */
+  --wact-sys-color-field:                          var(--wact-ref-palette-field40);
+  --wact-sys-color-on-field:                       var(--wact-ref-palette-field-on);
+  --wact-sys-color-field-line:                     var(--wact-ref-palette-field-line);
+  --wact-sys-color-field-label:                    var(--wact-ref-palette-field-label);
+
+  /* Ball */
+  --wact-sys-color-ball:                           var(--wact-ref-palette-ball60);
+  --wact-sys-color-on-ball:                        var(--wact-ref-palette-ball-outline);
+
+  /* Game result states (win / lose / tie) */
+  --wact-sys-color-win-overlay:                    var(--wact-ref-palette-success-overlay);
+  --wact-sys-color-win-outline:                    var(--wact-ref-palette-success-border);
+  --wact-sys-color-lose-overlay:                   var(--wact-ref-palette-defeat-overlay);
+  --wact-sys-color-lose-outline:                   var(--wact-ref-palette-defeat-border);
+  --wact-sys-color-tie-overlay:                    var(--wact-ref-palette-transparent70);
+  --wact-sys-color-tie-outline:                    var(--wact-ref-palette-neutral50);
+
+  /* Transparent */
+  --wact-sys-color-transparent:                    var(--wact-ref-palette-transparent0);
+}
+
+/* ── Dark mode ─────────────────────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) {
+  :host {
+    --wact-sys-color-nav:                            var(--wact-ref-palette-primary5);
+    --wact-sys-color-background:                     var(--wact-ref-palette-primary10);
+    --wact-sys-color-on-background:                  var(--wact-ref-palette-primary99);
+    --wact-sys-color-surface:                        var(--wact-ref-palette-primary20);
+    --wact-sys-color-surface-raised:                 var(--wact-ref-palette-primary20);
+    --wact-sys-color-surface-recessed:               var(--wact-ref-palette-primary17);
+    --wact-sys-color-surface-container-hover:        var(--wact-ref-palette-primary23);
+    --wact-sys-color-on-surface:                     var(--wact-ref-palette-primary99);
+    --wact-sys-color-on-surface-variant:             var(--wact-ref-palette-neutral80);
+    --wact-sys-color-on-surface-muted:               var(--wact-ref-palette-neutral40);
+    --wact-sys-color-interactive:                    var(--wact-ref-palette-primary32);
+    --wact-sys-color-interactive-hover:              var(--wact-ref-palette-primary43);
+    --wact-sys-color-interactive-active:             var(--wact-ref-palette-primary47);
+    --wact-sys-color-primary:                        var(--wact-ref-palette-primary30);
+    --wact-sys-color-primary-hover:                  var(--wact-ref-palette-primary35);
+    --wact-sys-color-primary-active:                 var(--wact-ref-palette-primary45);
+    --wact-sys-color-tertiary:                       var(--wact-ref-palette-tertiary82);
+    --wact-sys-color-tertiary-status:                var(--wact-ref-palette-tertiary82);
+    --wact-sys-color-destructive:                    var(--wact-ref-palette-error25);
+    --wact-sys-color-destructive-hover:              var(--wact-ref-palette-error30);
+    --wact-sys-color-destructive-active:             var(--wact-ref-palette-error40);
+    --wact-sys-color-error:                          var(--wact-ref-palette-error70);
+    --wact-sys-color-error-container:                var(--wact-ref-palette-error10);
+    --wact-sys-color-on-error-container:             var(--wact-ref-palette-error70);
+    --wact-sys-color-outline:                        var(--wact-ref-palette-neutral20);
+    --wact-sys-color-outline-variant:                var(--wact-ref-palette-neutral20);
+    --wact-sys-color-outline-field:                  var(--wact-ref-palette-neutral27);
+    --wact-sys-color-outline-card:                   var(--wact-ref-palette-primary37);
+    --wact-sys-color-feedback:                       var(--wact-ref-palette-neutral16);
+    --wact-sys-color-feedback-progress:              var(--wact-ref-palette-neutral22);
+    --wact-sys-color-tooltip-container:              var(--wact-ref-palette-neutral20);
+  }
+}
+
+/* ── High-contrast (light) ──────────────────────────────────────────────────── */
+@media (prefers-contrast: more) {
+  :host {
+    --wact-sys-color-on-background:                  var(--wact-ref-palette-primary5);
+    --wact-sys-color-on-surface:                     var(--wact-ref-palette-primary5);
+    --wact-sys-color-on-surface-variant:             var(--wact-ref-palette-neutral16);
+    --wact-sys-color-on-surface-muted:               var(--wact-ref-palette-neutral27);
+    --wact-sys-color-outline:                        var(--wact-ref-palette-neutral27);
+    --wact-sys-color-outline-variant:                var(--wact-ref-palette-neutral34);
+    --wact-sys-color-outline-field:                  var(--wact-ref-palette-neutral40);
+    --wact-sys-color-outline-card:                   var(--wact-ref-palette-primary47);
+    --wact-sys-color-primary:                        var(--wact-ref-palette-primary28);
+    --wact-sys-color-primary-hover:                  var(--wact-ref-palette-primary35);
+  }
+}
+
+/* ── High-contrast (dark) ───────────────────────────────────────────────────── */
+@media (prefers-color-scheme: dark) and (prefers-contrast: more) {
+  :host {
+    --wact-sys-color-on-background:                  var(--wact-ref-palette-primary99);
+    --wact-sys-color-on-surface:                     var(--wact-ref-palette-primary99);
+    --wact-sys-color-on-surface-variant:             var(--wact-ref-palette-neutral83);
+    --wact-sys-color-on-surface-muted:               var(--wact-ref-palette-neutral75);
+    --wact-sys-color-outline:                        var(--wact-ref-palette-neutral80);
+    --wact-sys-color-outline-variant:                var(--wact-ref-palette-neutral74);
+    --wact-sys-color-outline-field:                  var(--wact-ref-palette-neutral60);
+    --wact-sys-color-outline-card:                   var(--wact-ref-palette-primary82);
+  }
+}
+`;
+
+export const COLOR_CSS = REF_COLOR_CSS + SYS_COLOR_CSS;

--- a/src/styles/elevation.ts
+++ b/src/styles/elevation.ts
@@ -1,0 +1,57 @@
+const REF_ELEVATION_CSS = `
+:host {
+  /* Light-mode shadows */
+  --wact-ref-elevation-level1:      0 2px 8px rgba(0, 0, 0, 0.15);
+  --wact-ref-elevation-level2:      2px 2px 5px 2px rgba(0, 0, 0, 0.70);
+
+  /* Dark-mode shadows (higher opacity so they remain visible on dark surfaces) */
+  --wact-ref-elevation-level1-dark: 0 2px 8px rgba(0, 0, 0, 0.40);
+  --wact-ref-elevation-level2-dark: 2px 2px 5px 2px rgba(0, 0, 0, 0.90);
+
+  /* Negative z-index values */
+  --wact-ref-layer-neg-1: -1;
+
+  /* Positive z-index */
+  --wact-ref-layer-1:     1;
+  --wact-ref-layer-2:     2;
+  --wact-ref-layer-3:     3;
+  --wact-ref-layer-4:     4;
+  --wact-ref-layer-5:     5;
+  --wact-ref-layer-6:     6;
+  --wact-ref-layer-7:     7;
+  --wact-ref-layer-8:     8;
+  --wact-ref-layer-9:     9;
+  --wact-ref-layer-10:    10;
+  --wact-ref-layer-100:   100;
+  --wact-ref-layer-1000:  1000;
+}
+`;
+
+const SYS_ELEVATION_CSS = `
+:host {
+  --wact-sys-elevation-level1: var(--wact-ref-elevation-level1);
+  --wact-sys-elevation-level2: var(--wact-ref-elevation-level2);
+
+  /* Named z-index layers for UI surfaces */
+  --wact-sys-zindex-dropdown: var(--wact-ref-layer-10);
+  --wact-sys-zindex-overlay:  var(--wact-ref-layer-100);
+  --wact-sys-zindex-sticky:   var(--wact-ref-layer-1000);
+
+  /* Generic internal component stacking layers */
+  --wact-sys-layer-neg-1: var(--wact-ref-layer-neg-1);
+  --wact-sys-layer-1:     var(--wact-ref-layer-1);
+  --wact-sys-layer-2:     var(--wact-ref-layer-2);
+  --wact-sys-layer-3:     var(--wact-ref-layer-3);
+  --wact-sys-layer-4:     var(--wact-ref-layer-4);
+  --wact-sys-layer-5:     var(--wact-ref-layer-5);
+}
+
+@media (prefers-color-scheme: dark) {
+  :host {
+    --wact-sys-elevation-level1: var(--wact-ref-elevation-level1-dark);
+    --wact-sys-elevation-level2: var(--wact-ref-elevation-level2-dark);
+  }
+}
+`;
+
+export const ELEVATION_CSS = REF_ELEVATION_CSS + SYS_ELEVATION_CSS;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,29 @@
+import { COLOR_CSS } from './color.js';
+import { ELEVATION_CSS } from './elevation.js';
+import { LAYOUT_CSS } from './layout.js';
+import { MOTION_CSS } from './motion.js';
+import { SHAPE_CSS } from './shape.js';
+import { SPACING_CSS } from './spacing.js';
+import { STATE_CSS } from './state.js';
+import { TYPEFACE_CSS } from './typeface.js';
+
+export {
+  COLOR_CSS,
+  ELEVATION_CSS,
+  LAYOUT_CSS,
+  MOTION_CSS,
+  SHAPE_CSS,
+  SPACING_CSS,
+  STATE_CSS,
+  TYPEFACE_CSS,
+};
+
+export const DESIGN_TOKENS_CSS =
+  COLOR_CSS +
+  ELEVATION_CSS +
+  LAYOUT_CSS +
+  MOTION_CSS +
+  SHAPE_CSS +
+  SPACING_CSS +
+  STATE_CSS +
+  TYPEFACE_CSS;

--- a/src/styles/layout.ts
+++ b/src/styles/layout.ts
@@ -1,0 +1,76 @@
+const REF_LAYOUT_CSS = `
+:host {
+    /* Fit parent or no size */
+    --wact-ref-layout-none: 0%;
+    --wact-ref-layout-fit-container: 100%;
+
+    /* Viewport height */
+    --wact-ref-layout-vh-10: 10vh;
+    --wact-ref-layout-vh-20: 20vh;
+    --wact-ref-layout-vh-30: 30vh;
+    --wact-ref-layout-vh-40: 40vh;
+    --wact-ref-layout-vh-50: 50vh;
+    --wact-ref-layout-vh-60: 60vh;
+    --wact-ref-layout-vh-70: 70vh;
+    --wact-ref-layout-vh-80: 80vh;
+    --wact-ref-layout-vh-90: 90vh;
+
+    /* Viewport width */
+    --wact-ref-layout-vw-10: 10vw;
+    --wact-ref-layout-vw-20: 20vw;
+    --wact-ref-layout-vw-30: 30vw;
+    --wact-ref-layout-vw-40: 40vw;
+    --wact-ref-layout-vw-50: 50vw;
+    --wact-ref-layout-vw-60: 60vw;
+    --wact-ref-layout-vw-70: 70vw;
+    --wact-ref-layout-vw-80: 80vw;
+    --wact-ref-layout-vw-90: 90vw;
+
+    /* Pixel width and height */
+    --wact-ref-layout-px-1:     1px;
+    --wact-ref-layout-px-2:     2px;
+    --wact-ref-layout-px-4:     4px;
+    --wact-ref-layout-px-8:     8px;
+    --wact-ref-layout-px-16:    16px;
+    --wact-ref-layout-px-32:    32px;
+    --wact-ref-layout-px-48:    48px;
+    --wact-ref-layout-px-64:    64px;
+    --wact-ref-layout-px-96:    96px;
+    --wact-ref-layout-px-128:   128px;
+    --wact-ref-layout-px-160:   160px;
+    --wact-ref-layout-px-192:   192px;
+    --wact-ref-layout-px-256:   256px;
+    --wact-ref-layout-px-320:   320px;
+    --wact-ref-layout-px-384:   386px;
+    --wact-ref-layout-px-512:   512px;
+    --wact-ref-layout-px-600:   600px;
+    --wact-ref-layout-px-640:   640px;
+    --wact-ref-layout-px-2048:  2048px;
+}
+`;
+
+const SYS_LAYOUT_CSS = `
+:host {
+    /* Height and width to fit the parent container */
+    --wact-sys-layout-fit-container: var(--wact-ref-layout-fit-container);
+
+    /* Minimum click target height and width */
+    --wact-sys-layout-min-target-size: var(--wact-ref-layout-px-48);
+
+    /* Height of large banner */
+    --wact-sys-layout-banner-large-height: var(--wact-ref-layout-vh-20);
+    --wact-sys-layout-banner-large-max-height: var(--wact-ref-layout-px-160);
+
+    /* Height of field display */
+    --wact-sys-layout-field-height: var(--wact-ref-layout-vh-20);
+    --wact-sys-layout-field-min-height: var(--wact-ref-layout-px-128);
+}
+
+@media only screen and (max-width: 600px) {
+    :host {
+        --wact-sys-layout-field-min-height: var(--wact-ref-layout-px-96);
+    }
+}
+`;
+
+export const LAYOUT_CSS = REF_LAYOUT_CSS + SYS_LAYOUT_CSS;

--- a/src/styles/motion.ts
+++ b/src/styles/motion.ts
@@ -1,0 +1,42 @@
+const REF_MOTION_CSS = `
+:host {
+  --wact-ref-motion-duration-short1:  150ms;
+  --wact-ref-motion-duration-short2:  200ms;
+  --wact-ref-motion-duration-medium1: 300ms;
+  --wact-ref-motion-duration-medium2: 400ms;
+  --wact-ref-motion-duration-long1:   600ms;
+  --wact-ref-motion-duration-long2:   1000ms;
+  --wact-ref-motion-duration-long3:   1200ms;
+  --wact-ref-motion-easing-standard:  ease;
+  --wact-ref-motion-easing-linear:    linear;
+}
+`;
+
+const SYS_MOTION_CSS = `
+:host {
+  --wact-sys-motion-duration-short1:  var(--wact-ref-motion-duration-short1);
+  --wact-sys-motion-duration-short2:  var(--wact-ref-motion-duration-short2);
+  --wact-sys-motion-duration-medium1: var(--wact-ref-motion-duration-medium1);
+  --wact-sys-motion-duration-medium2: var(--wact-ref-motion-duration-medium2);
+  --wact-sys-motion-duration-long1:   var(--wact-ref-motion-duration-long1);
+  --wact-sys-motion-duration-long2:   var(--wact-ref-motion-duration-long2);
+  --wact-sys-motion-duration-long3:   var(--wact-ref-motion-duration-long3);
+  --wact-sys-motion-easing-standard:  var(--wact-ref-motion-easing-standard);
+  --wact-sys-motion-easing-linear:    var(--wact-ref-motion-easing-linear);
+}
+
+/* Users who prefer reduced motion get near-instant transitions */
+@media (prefers-reduced-motion: reduce) {
+  :host {
+    --wact-sys-motion-duration-short1:  1ms;
+    --wact-sys-motion-duration-short2:  1ms;
+    --wact-sys-motion-duration-medium1: 1ms;
+    --wact-sys-motion-duration-medium2: 1ms;
+    --wact-sys-motion-duration-long1:   1ms;
+    --wact-sys-motion-duration-long2:   1ms;
+    --wact-sys-motion-duration-long3:   1ms;
+  }
+}
+`;
+
+export const MOTION_CSS = REF_MOTION_CSS + SYS_MOTION_CSS;

--- a/src/styles/shape.ts
+++ b/src/styles/shape.ts
@@ -1,0 +1,23 @@
+const REF_SHAPE_CSS = `
+:host {
+  --wact-ref-shape-corner-micro:       2px;
+  --wact-ref-shape-corner-extra-small: 4px;
+  --wact-ref-shape-corner-small:       6px;
+  --wact-ref-shape-corner-medium:      8px;
+  --wact-ref-shape-corner-large:       12px;
+  --wact-ref-shape-corner-full:        50%;
+}
+`;
+
+const SYS_SHAPE_CSS = `
+:host {
+  --wact-sys-shape-corner-micro:       var(--wact-ref-shape-corner-micro);
+  --wact-sys-shape-corner-extra-small: var(--wact-ref-shape-corner-extra-small);
+  --wact-sys-shape-corner-small:       var(--wact-ref-shape-corner-small);
+  --wact-sys-shape-corner-medium:      var(--wact-ref-shape-corner-medium);
+  --wact-sys-shape-corner-large:       var(--wact-ref-shape-corner-large);
+  --wact-sys-shape-corner-full:        var(--wact-ref-shape-corner-full);
+}
+`;
+
+export const SHAPE_CSS = REF_SHAPE_CSS + SYS_SHAPE_CSS;

--- a/src/styles/spacing.ts
+++ b/src/styles/spacing.ts
@@ -1,0 +1,43 @@
+const REF_SPACING_CSS = `
+:host {
+  --wact-ref-spacing-xs:  4px;
+  --wact-ref-spacing-sm:  8px;
+  --wact-ref-spacing-md:  12px;
+  --wact-ref-spacing-lg:  16px;
+  --wact-ref-spacing-xl:  20px;
+  --wact-ref-spacing-2xl: 24px;
+  --wact-ref-spacing-3xl: 40px;
+}
+`;
+
+const SYS_SPACING_CSS = `
+:host {
+  --wact-sys-spacing-xs:  var(--wact-ref-spacing-xs);
+  --wact-sys-spacing-sm:  var(--wact-ref-spacing-sm);
+  --wact-sys-spacing-md:  var(--wact-ref-spacing-md);
+  --wact-sys-spacing-lg:  var(--wact-ref-spacing-lg);
+  --wact-sys-spacing-xl:  var(--wact-ref-spacing-xl);
+  --wact-sys-spacing-2xl: var(--wact-ref-spacing-2xl);
+  --wact-sys-spacing-3xl: var(--wact-ref-spacing-3xl);
+}
+
+/* Tablet and up: slightly more generous spacing */
+@media only screen and (min-width: 768px) {
+  :host {
+    --wact-sys-spacing-xl:  22px;
+    --wact-sys-spacing-2xl: 28px;
+    --wact-sys-spacing-3xl: 48px;
+  }
+}
+
+/* Desktop: full-density spacing */
+@media only screen and (min-width: 1024px) {
+  :host {
+    --wact-sys-spacing-xl:  24px;
+    --wact-sys-spacing-2xl: 32px;
+    --wact-sys-spacing-3xl: 56px;
+  }
+}
+`;
+
+export const SPACING_CSS = REF_SPACING_CSS + SYS_SPACING_CSS;

--- a/src/styles/state.ts
+++ b/src/styles/state.ts
@@ -1,0 +1,15 @@
+const REF_STATE_CSS = `
+:host {
+  --wact-ref-state-layer-opacity-disabled: 0.4;
+  --wact-ref-state-layer-opacity-inactive: 0.45;
+}
+`;
+
+const SYS_STATE_CSS = `
+:host {
+  --wact-sys-state-layer-opacity-disabled: var(--wact-ref-state-layer-opacity-disabled);
+  --wact-sys-state-layer-opacity-inactive: var(--wact-ref-state-layer-opacity-inactive);
+}
+`;
+
+export const STATE_CSS = REF_STATE_CSS + SYS_STATE_CSS;

--- a/src/styles/typeface.ts
+++ b/src/styles/typeface.ts
@@ -1,0 +1,81 @@
+const REF_TYPEFACE_CSS = `
+:host {
+  /* Font and weight */
+  --wact-ref-typeface-font-family:    sans-serif;
+  --wact-ref-typeface-weight-normal:  normal;
+  --wact-ref-typeface-weight-bold:    bold;
+  --wact-ref-typeface-weight-italic:  italic;
+
+  /* Font size */
+  --wact-ref-typeface-xxs-0:    0.50em;
+  --wact-ref-typeface-xxs-1:    0.55em;
+  --wact-ref-typeface-xxs-2:    0.60em;
+  --wact-ref-typeface-xs-0:     0.65em;
+  --wact-ref-typeface-xs-1:     0.70em;
+  --wact-ref-typeface-xs-2:     0.75em;
+  --wact-ref-typeface-small-0:  0.80em;
+  --wact-ref-typeface-small-1:  0.90em;
+  --wact-ref-typeface-small-2:  1.00em;
+  --wact-ref-typeface-medium-0: 1.10em;
+  --wact-ref-typeface-medium-1: 1.30em;
+  --wact-ref-typeface-medium-2: 1.50em;
+  --wact-ref-typeface-medium-3: 1.70em;
+  --wact-ref-typeface-large-0:  1.80em;
+  --wact-ref-typeface-large-1:  2.00em;
+  --wact-ref-typeface-large-2:  2.20em;
+  --wact-ref-typeface-large-3:  2.40em;
+
+  /* Line height */
+  --wact-ref-typeface-line-height-body: 1.4;
+}
+`;
+
+const SYS_TYPEFACE_CSS = `
+:host {
+  /* Font and weight */
+  --wact-sys-typeface-font-family:          var(--wact-ref-typeface-font-family);
+  --wact-sys-typeface-weight-normal:        var(--wact-ref-typeface-weight-normal);
+  --wact-sys-typeface-weight-bold:          var(--wact-ref-typeface-weight-bold);
+  --wact-sys-typeface-weight-italic:        var(--wact-ref-typeface-weight-italic);
+
+  /* Label scale */
+  --wact-sys-typeface-label-small-size:     var(--wact-ref-typeface-xs-0);
+  --wact-sys-typeface-label-medium-size:    var(--wact-ref-typeface-xs-1);
+  --wact-sys-typeface-label-large-size:     var(--wact-ref-typeface-xs-2);
+
+  /* Body scale */
+  --wact-sys-typeface-body-small-size:      var(--wact-ref-typeface-small-0);
+  --wact-sys-typeface-body-medium-size:     var(--wact-ref-typeface-small-1);
+  --wact-sys-typeface-body-large-size:      var(--wact-ref-typeface-small-2);
+
+  /* Title scale */
+  --wact-sys-typeface-title-small-size:     var(--wact-ref-typeface-medium-0);
+  --wact-sys-typeface-title-medium-size:    var(--wact-ref-typeface-medium-1);
+  --wact-sys-typeface-title-large-size:     var(--wact-ref-typeface-medium-2);
+
+  /* Display scale */
+  --wact-sys-typeface-display-small-size:   var(--wact-ref-typeface-large-0);
+  --wact-sys-typeface-display-medium-size:  var(--wact-ref-typeface-large-1);
+  --wact-sys-typeface-display-large-size:   var(--wact-ref-typeface-large-2);
+
+  /* Line height */
+  --wact-sys-typeface-line-height-body:     var(--wact-ref-typeface-line-height-body);
+}
+
+/* Larger viewports: bump display and title sizes for better visual hierarchy */
+@media only screen and (min-width: 1024px) {
+  :host {
+    /* Title scale */
+    --wact-sys-typeface-title-small-size:   var(--wact-ref-typeface-medium-1);
+    --wact-sys-typeface-title-medium-size:  var(--wact-ref-typeface-medium-2);
+    --wact-sys-typeface-title-large-size:   var(--wact-ref-typeface-medium-3);
+
+    /* Display scale */
+    --wact-sys-typeface-display-small-size:   var(--wact-ref-typeface-large-1);
+    --wact-sys-typeface-display-medium-size:  var(--wact-ref-typeface-large-2);
+    --wact-sys-typeface-display-large-size:   var(--wact-ref-typeface-large-3);
+  }
+}
+`;
+
+export const TYPEFACE_CSS = REF_TYPEFACE_CSS + SYS_TYPEFACE_CSS;


### PR DESCRIPTION
Cherry-pick of PR:
- https://github.com/whatsacomputertho/fbsim-ui/pull/23

For reference, see:
- https://github.com/whatsacomputertho/fbsim-ui/issues/21

Includes commits:
* refac(style): implement design tokens as source of truth for styling
* feat(demo): add design token demo page
* refac(style): context-aware system & component tokens, high-contrast
* fix(ci): fix formatting, failing unit tests
* refac(styles): continue to refactor into design tokens
* refac(styles): refactor component styles into design tokens
* fix(style): fix broken design token refs