### PR TITLE
feat(icon): create wact-icon component

### DIFF
--- a/src/components/icons/arrow-right.ts
+++ b/src/components/icons/arrow-right.ts
@@ -1,0 +1,1 @@
+export const arrowRight = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>`;

--- a/src/components/icons/chart.ts
+++ b/src/components/icons/chart.ts
@@ -1,0 +1,1 @@
+export const chart = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="20" x2="22" y2="20"/><polyline points="4 16 10 9 16 13 22 7"/></svg>`;

--- a/src/components/icons/pause.ts
+++ b/src/components/icons/pause.ts
@@ -1,0 +1,1 @@
+export const pause = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>`;

--- a/src/components/icons/play.ts
+++ b/src/components/icons/play.ts
@@ -1,0 +1,1 @@
+export const play = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 3 19 12 5 21 5 3"/></svg>`;

--- a/src/components/icons/skip.ts
+++ b/src/components/icons/skip.ts
@@ -1,0 +1,1 @@
+export const skip = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%" fill="currentColor" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="5 4 15 12 5 20 5 4"/><line x1="19" y1="5" x2="19" y2="19" fill="none"/></svg>`;

--- a/src/components/icons/spinner.ts
+++ b/src/components/icons/spinner.ts
@@ -1,0 +1,1 @@
+export const spinner = `<span class="icon__spinner"></span>`;

--- a/src/components/icons/upload.ts
+++ b/src/components/icons/upload.ts
@@ -1,0 +1,1 @@
+export const upload = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="100%" height="100%" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export { WACTIcon } from './wact-icon.js';
 export { WACTButton } from './wact-button.js';
 export { WACTNav } from './wact-nav.js';
 export { WACTTeamSelect } from './wact-team-select.js';

--- a/src/components/wact-button.ts
+++ b/src/components/wact-button.ts
@@ -99,19 +99,8 @@ template.innerHTML = `
       display: none !important;
     }
 
-    .spinner {
-      width: var(--wact-comp-button-icon-size);
-      height: var(--wact-comp-button-icon-size);
-      border: 2px solid var(--wact-comp-button-label-color);
-      border-top-color: transparent;
-      border-radius: var(--wact-sys-shape-corner-full);
-      animation: spin var(--wact-sys-motion-duration-long1) var(--wact-sys-motion-easing-linear) infinite;
-      display: inline-block;
-      vertical-align: middle;
-    }
-
-    @keyframes spin {
-      to { transform: rotate(360deg); }
+    #btn-spinner {
+      --wact-comp-icon-size: var(--wact-comp-button-icon-size);
     }
 
     #btn[data-tooltip]::after {
@@ -138,7 +127,7 @@ template.innerHTML = `
   </style>
   <button part="button" id="btn">
     <span id="btn-content"><slot></slot></span>
-    <span id="btn-spinner" class="spinner hidden"></span>
+    <wact-icon id="btn-spinner" icon="spinner" class="hidden"></wact-icon>
     <span id="btn-confirm" class="hidden"></span>
   </button>
 `;

--- a/src/components/wact-game-sim.ts
+++ b/src/components/wact-game-sim.ts
@@ -164,6 +164,7 @@ template.innerHTML = `
       align-items: center;
       justify-content: center;
       color: var(--wact-comp-game-sim-card-title-color);
+      --wact-comp-icon-size: var(--wact-ref-layout-px-32);
     }
 
     .game-sim__mode-card-icons {
@@ -174,17 +175,8 @@ template.innerHTML = `
       margin-left: auto;
     }
 
-    @keyframes game-sim-spin {
-      to { transform: rotate(360deg); }
-    }
-
     .game-sim__card-spinner {
-      width: var(--wact-comp-game-sim-icon-size-sm);
-      height: var(--wact-comp-game-sim-icon-size-sm);
-      border: 2px solid currentColor;
-      border-top-color: transparent;
-      border-radius: var(--wact-sys-shape-corner-full);
-      animation: game-sim-spin var(--wact-sys-motion-duration-long1) var(--wact-sys-motion-easing-linear) infinite;
+      --wact-comp-icon-size: var(--wact-comp-game-sim-icon-size-sm);
     }
 
     #game-sim__file-error {
@@ -356,7 +348,7 @@ template.innerHTML = `
         <div class="game-sim__mode-card-row">
           <div class="game-sim__mode-card-icons">
             <div class="game-sim__mode-icon" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+              <wact-icon icon="arrow-right"></wact-icon>
             </div>
           </div>
         </div>
@@ -368,15 +360,15 @@ template.innerHTML = `
         <div class="game-sim__mode-card-subtitle">Play-back a game that has already been simulated</div>
         <div class="game-sim__mode-card-row">
           <wact-button id="game-sim__replay-upload-btn" aria-label="Upload game file" tooltip="upload game">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            <wact-icon icon="upload"></wact-icon>
           </wact-button>
           <span id="game-sim__replay-status" class="game-sim__replay-status">No game selected</span>
           <div class="game-sim__mode-card-icons">
             <div id="game-sim__replay-arrow" class="game-sim__mode-icon" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+              <wact-icon icon="arrow-right"></wact-icon>
             </div>
             <div id="game-sim__replay-spinner" class="game-sim__mode-icon" aria-hidden="true" style="display:none">
-              <div class="game-sim__card-spinner"></div>
+              <wact-icon icon="spinner" class="game-sim__card-spinner"></wact-icon>
             </div>
           </div>
         </div>
@@ -410,13 +402,13 @@ template.innerHTML = `
             <div id="game-sim__postgame-actions">
               <wact-button id="game-sim__export-button" class="game-sim__postgame-icon-btn">
                 <span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                  <wact-icon icon="upload"></wact-icon>
                   Export
                 </span>
               </wact-button>
               <wact-button id="game-sim__summary-button" class="game-sim__postgame-icon-btn">
                 <span>
-                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="2" y1="20" x2="22" y2="20"/><polyline points="4 16 10 9 16 13 22 7"/></svg>
+                  <wact-icon icon="chart"></wact-icon>
                   Game Summary
                 </span>
               </wact-button>

--- a/src/components/wact-icon.ts
+++ b/src/components/wact-icon.ts
@@ -1,0 +1,93 @@
+import { MOTION_CSS, SHAPE_CSS } from '../styles/index.js';
+import { arrowRight } from './icons/arrow-right.js';
+import { chart } from './icons/chart.js';
+import { pause } from './icons/pause.js';
+import { play } from './icons/play.js';
+import { skip } from './icons/skip.js';
+import { spinner } from './icons/spinner.js';
+import { upload } from './icons/upload.js';
+
+const ICONS: Record<string, string> = {
+  'arrow-right': arrowRight,
+  chart,
+  pause,
+  play,
+  skip,
+  spinner,
+  upload,
+};
+
+const template = document.createElement('template');
+template.innerHTML = `
+  <style>
+    ${MOTION_CSS}
+    ${SHAPE_CSS}
+
+    :host {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      vertical-align: middle;
+      width: var(--wact-comp-icon-size, 1em);
+      height: var(--wact-comp-icon-size, 1em);
+    }
+
+    .icon__spinner {
+      display: block;
+      width: var(--wact-comp-icon-size, 1em);
+      height: var(--wact-comp-icon-size, 1em);
+      border: 2px solid currentColor;
+      border-top-color: transparent;
+      border-radius: var(--wact-sys-shape-corner-full);
+      animation: spin var(--wact-sys-motion-duration-long1) var(--wact-sys-motion-easing-linear) infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+  </style>
+  <span id="icon__container"></span>
+`;
+
+export class WACTIcon extends HTMLElement {
+  static readonly tagName = 'wact-icon' as const;
+
+  readonly root: ShadowRoot;
+
+  constructor() {
+    super();
+    this.root = this.attachShadow({ mode: 'open' });
+    this.root.append(template.content.cloneNode(true));
+  }
+
+  static get observedAttributes(): string[] {
+    return ['icon'];
+  }
+
+  get icon(): string {
+    return this.getAttribute('icon') ?? '';
+  }
+
+  set icon(value: string) {
+    this.setAttribute('icon', value);
+  }
+
+  private render(): void {
+    const container = this.root.getElementById('icon__container') as HTMLSpanElement;
+    container.innerHTML = ICONS[this.icon] ?? '';
+  }
+
+  attributeChangedCallback(
+    attribute: string,
+    _previousValue: string | null,
+    _newValue: string | null,
+  ): void {
+    if (attribute === 'icon') {
+      this.render();
+    }
+  }
+
+  connectedCallback(): void {
+    this.render();
+  }
+}

--- a/src/components/wact-playback-controls.ts
+++ b/src/components/wact-playback-controls.ts
@@ -1,10 +1,11 @@
-import { COLOR_CSS, ELEVATION_CSS, SHAPE_CSS, SPACING_CSS } from '../styles/index.js';
+import { COLOR_CSS, ELEVATION_CSS, LAYOUT_CSS, SHAPE_CSS, SPACING_CSS } from '../styles/index.js';
 
 const template = document.createElement('template');
 template.innerHTML = `
   <style>
     ${COLOR_CSS}
     ${ELEVATION_CSS}
+    ${LAYOUT_CSS}
     ${SHAPE_CSS}
     ${SPACING_CSS}
 
@@ -164,14 +165,14 @@ template.innerHTML = `
   </style>
   <div id="playback__wrapper">
     <div id="playback__left">
-      <wact-button id="playback__play-pause" class="playback__button" tooltip="Play">&#9654;</wact-button>
+      <wact-button id="playback__play-pause" class="playback__button" tooltip="Play"><wact-icon icon="play"></wact-icon></wact-button>
     </div>
     <div id="playback__right">
       <div id="playback__speed-wrapper">
         <button id="playback__speed-display">2x</button>
         <div id="playback__speed-menu"></div>
       </div>
-      <wact-button id="playback__skip" class="playback__button" tooltip="Skip to end">&#9197;</wact-button>
+      <wact-button id="playback__skip" class="playback__button" tooltip="Skip to end"><wact-icon icon="skip"></wact-icon></wact-button>
     </div>
   </div>
 `;
@@ -236,11 +237,12 @@ export class WACTPlaybackControls extends HTMLElement {
 
   private updatePlayPauseButton(): void {
     const button = this.root.getElementById('playback__play-pause') as HTMLElement;
+    const icon = button.querySelector('wact-icon') as HTMLElement;
     if (this.playing) {
-      button.innerHTML = '&#9208;';
+      icon.setAttribute('icon', 'pause');
       button.setAttribute('tooltip', 'Pause');
     } else {
-      button.innerHTML = '&#9654;';
+      icon.setAttribute('icon', 'play');
       button.setAttribute('tooltip', 'Play');
     }
   }

--- a/src/components/wact-team-config.ts
+++ b/src/components/wact-team-config.ts
@@ -1,6 +1,7 @@
 import type { TeamConfig } from '../services/types.js';
 import {
   COLOR_CSS,
+  ELEVATION_CSS,
   LAYOUT_CSS,
   MOTION_CSS,
   SHAPE_CSS,
@@ -12,6 +13,7 @@ const template = document.createElement('template');
 template.innerHTML = `
   <style>
     ${COLOR_CSS}
+    ${ELEVATION_CSS}
     ${LAYOUT_CSS}
     ${MOTION_CSS}
     ${SHAPE_CSS}
@@ -209,6 +211,7 @@ template.innerHTML = `
       display: flex;
       justify-content: space-between;
       align-items: center;
+      transition: color var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     .team-config__section-header:hover {
@@ -228,14 +231,21 @@ template.innerHTML = `
       display: grid;
       grid-template-columns: 1fr 1fr;
       gap: var(--wact-sys-spacing-xs) var(--wact-sys-spacing-md);
+      max-height: var(--wact-ref-layout-px-512);
+      overflow: hidden;
+      transition: max-height var(--wact-sys-motion-duration-short2) var(--wact-sys-motion-easing-standard);
     }
 
     .team-config__section-content--collapsed {
-      display: none;
+      max-height: 0;
     }
 
     #team-config__load-btn {
-      margin-top: var(--wact-comp-team-config-btn-margin-top);
+      display: block;
+      width: fit-content;
+      margin: var(--wact-comp-team-config-btn-margin-top) auto 0;
+      position: relative;
+      z-index: var(--wact-sys-zindex-dropdown);
       --btn-padding: var(--wact-comp-team-config-btn-padding);
       font-size: var(--wact-comp-team-config-btn-font-size);
     }
@@ -290,7 +300,7 @@ template.innerHTML = `
         <input id="team-config__logo-url-input" type="text" value="https://official-flc.com/img/default-club-picture.png">
       </div>
     </div>
-    <wact-button id="team-config__load-btn">Load from File</wact-button>
+    <wact-button id="team-config__load-btn" tooltip="Load from file"><wact-icon icon="upload"></wact-icon></wact-button>
     <input id="team-config__file-input" type="file" accept=".json">
     <div id="team-config__error"></div>
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,3 +1,4 @@
+import { WACTIcon } from './components/wact-icon.js';
 import { WACTButton } from './components/wact-button.js';
 import { WACTNav } from './components/wact-nav.js';
 import { WACTTeamSelect } from './components/wact-team-select.js';
@@ -15,6 +16,7 @@ import { WACTGameContext } from './components/wact-game-context.js';
 import { WACTGameSim } from './components/wact-game-sim.js';
 
 const components = [
+  WACTIcon,
   WACTButton,
   WACTNav,
   WACTTeamSelect,


### PR DESCRIPTION
In this PR I create a new component, `wact-icon`, which contains various registered SVG icons which can be selected through its observed attributes.

For reference, see:
- https://github.com/whatsacomputertho/fbsim-ui/issues/22